### PR TITLE
FE 로그아웃 API 적용 및 Mock API 설정 (#19)

### DIFF
--- a/client/src/components/Profile/UserProfile/UserProfile.tsx
+++ b/client/src/components/Profile/UserProfile/UserProfile.tsx
@@ -1,8 +1,13 @@
 import React from "react";
 
 import "./UserProfile.scss";
+import { logOutAPI } from "@/apis/auth";
+import customLocalStorage from "@/utils/localStorage";
+import useAuthStore from "@/store/useAuthStore";
 
 const UserProfile = (): JSX.Element => {
+  const logout = useAuthStore((state) => state.logout);
+
   // TODO : RQ로 처리하도록 변경
   const user = {
     name: "shyuuuuni",
@@ -10,8 +15,21 @@ const UserProfile = (): JSX.Element => {
       "https://avatars.githubusercontent.com/u/63703962?s…00&u=77dcbc41de6315d0355e67cca4174dad51a9a50f&v=4",
   };
 
+  /**
+   * 로컬스토리지에 expiresIn 지우기
+   * 서버에 지워달라 요청
+   */
+  const handleLogout = (): void => {
+    logOutAPI()
+      .then(() => {
+        customLocalStorage.removeItem("expiresIn");
+        logout();
+      })
+      .catch((e) => console.log("로그아웃 실패", e));
+  };
+
   return (
-    <div className="user-profile">
+    <div className="user-profile" onClick={handleLogout}>
       <img className="user-profile__image" src={user.avatar_url} />
       <div className="user-profile__name">{user.name}</div>
     </div>

--- a/client/src/mocks/handlers.ts
+++ b/client/src/mocks/handlers.ts
@@ -1,11 +1,3 @@
-import { rest } from "msw";
-import { mockUser } from "@/mocks/mockData";
+import { authHandlers } from "@/mocks/handlers/authHandler";
 
-export const handlers = [
-  rest.get("http://localhost:8000/api/auth/github", (req, res, ctx) => {
-    const code = req.url.searchParams.get("code");
-    if (code != null) {
-      return res(ctx.status(200), ctx.delay(1000), ctx.json(mockUser));
-    }
-  }),
-];
+export const handlers = [...authHandlers];

--- a/client/src/mocks/handlers/authHandler.ts
+++ b/client/src/mocks/handlers/authHandler.ts
@@ -1,0 +1,17 @@
+import { rest } from "msw";
+import { mockUser } from "@/mocks/mockData";
+
+// Backend API Server URL
+const baseUrl = import.meta.env.VITE_API_SERVER_URL;
+
+export const authHandlers = [
+  rest.get(`${baseUrl}auth/github`, (req, res, ctx) => {
+    const code = req.url.searchParams.get("code");
+    if (code != null) {
+      return res(ctx.status(200), ctx.delay(1000), ctx.json(mockUser));
+    }
+  }),
+  rest.delete(`${baseUrl}auth/logout`, (req, res, ctx) => {
+    return res(ctx.status(200));
+  }),
+];

--- a/client/src/utils/localStorage.ts
+++ b/client/src/utils/localStorage.ts
@@ -1,6 +1,7 @@
 interface CustomLocalStorage {
   getItem: (key: string) => string;
   setItem: (key: string, value: string) => void;
+  removeItem: (key: string) => void;
 }
 
 const customLocalStorage: CustomLocalStorage = {
@@ -16,6 +17,14 @@ const customLocalStorage: CustomLocalStorage = {
     try {
       const storedValue = localStorage.getItem(key);
       return storedValue !== null ? JSON.parse(storedValue) : null;
+    } catch (e: any) {
+      alert(e.message);
+    }
+  },
+
+  removeItem: (key) => {
+    try {
+      localStorage.removeItem(key);
     } catch (e: any) {
       alert(e.message);
     }


### PR DESCRIPTION
# 요약

- 디자인 생각 없이 로그인 된 상태의 프로필 컴포넌트 클릭 시 로그아웃 로직이 작동되도록 구현함
- msw handler를 카테고리별로 분리할 수 있도록 리팩토링

# 연관 이슈

- closed #19 

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
    - 좋은 예시) feat [FE] : 깃허브 로그인 버튼 컴포넌트 구현 (#13)
    - 나쁜 예시) feat: 로그인 구현