### PR TITLE
로그인 하고 로그아웃 하는 시나리오에 맞추어 Cypress 테스트를 작성했습니다.

### DIFF
--- a/client/cypress.config.ts
+++ b/client/cypress.config.ts
@@ -1,15 +1,21 @@
 import { defineConfig } from "cypress";
+import vitePreprocessor from "cypress-vite";
+import * as path from "path";
 
 export default defineConfig({
   e2e: {
     setupNodeEvents(on, config) {
-      // implement node event listeners here
+      on(
+        "file:preprocessor",
+        vitePreprocessor(path.resolve(path.resolve(), "./vite.config.ts"))
+      );
     },
     env: {
       "cypress-react-selector": {
         root: "#root",
       },
     },
+    chromeWebSecurity: false,
     baseUrl: "http://localhost:5173",
   },
 });

--- a/client/cypress/e2e/login.cy.ts
+++ b/client/cypress/e2e/login.cy.ts
@@ -1,0 +1,31 @@
+describe("LogIn and LogOut Scenario", () => {
+  it("should redirect to github correctly", () => {
+    cy.visit("/");
+    cy.window().then(($win) => {
+      cy.stub($win, "open", (url: any) => {
+        $win.location.href = url;
+      }).as("popup");
+      cy.get("[data-cy=login-btn]").click();
+      cy.get("@popup").should("be.called");
+      cy.get("p").contains("GitHub");
+      cy.get(".btn").click();
+    });
+  });
+
+  it("click btn to login and click image to logout", () => {
+    /**
+     *     현재 로컬에서 한번 로그인 돼있는 것을 전제로 테스트
+     *     팝업 window에 새로운 id, 비밀번호 삽입하는 시나리오는 test 되지 않음 (현재 cypress double 탭을 지원하지 않는다.)
+     *     https://docs.cypress.io/guides/references/trade-offs  There will never be support for multiple browser tabs.
+     */
+    cy.visit("/");
+    cy.get("[data-cy=login-btn]").click();
+    cy.intercept("/api**/").then(() => {
+      cy.get(".user-profile", { timeout: 30000 });
+    });
+    cy.get(".user-profile").click();
+    cy.get("[data-cy=login-btn]");
+  });
+});
+
+export {};

--- a/client/cypress/e2e/spec.cy.ts
+++ b/client/cypress/e2e/spec.cy.ts
@@ -1,7 +1,0 @@
-describe("empty spec", () => {
-  it("passes", () => {
-    cy.visit("/");
-  });
-});
-
-export {};

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -29,6 +29,7 @@
         "@vitejs/plugin-react": "^2.2.0",
         "cypress": "^10.11.0",
         "cypress-react-selector": "^3.0.0",
+        "cypress-vite": "^1.2.1",
         "eslint": "^8.26.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-config-standard-with-typescript": "^23.0.0",
@@ -3983,6 +3984,18 @@
       "dev": true,
       "dependencies": {
         "resq": "1.10.2"
+      }
+    },
+    "node_modules/cypress-vite": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/cypress-vite/-/cypress-vite-1.2.1.tgz",
+      "integrity": "sha512-/72GXXTcKvIv4NPK64qngcuim5U8WtflyBz9N4dzCqxR6MiIcGAK1EukrOCDpyChYbmjUy6LqbWhAgvXcs8lFw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "peerDependencies": {
+        "vite": "^2.9.0 || ^3.0.0"
       }
     },
     "node_modules/cypress/node_modules/ansi-styles": {
@@ -14964,6 +14977,15 @@
       "dev": true,
       "requires": {
         "resq": "1.10.2"
+      }
+    },
+    "cypress-vite": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/cypress-vite/-/cypress-vite-1.2.1.tgz",
+      "integrity": "sha512-/72GXXTcKvIv4NPK64qngcuim5U8WtflyBz9N4dzCqxR6MiIcGAK1EukrOCDpyChYbmjUy6LqbWhAgvXcs8lFw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.3.4"
       }
     },
     "dashdash": {

--- a/client/package.json
+++ b/client/package.json
@@ -33,6 +33,7 @@
     "@vitejs/plugin-react": "^2.2.0",
     "cypress": "^10.11.0",
     "cypress-react-selector": "^3.0.0",
+    "cypress-vite": "^1.2.1",
     "eslint": "^8.26.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-config-standard-with-typescript": "^23.0.0",

--- a/client/src/components/Profile/NotLoggedInProfile/NotLoggedInProfile.tsx
+++ b/client/src/components/Profile/NotLoggedInProfile/NotLoggedInProfile.tsx
@@ -46,7 +46,11 @@ const NotLoggedInProfile = (): JSX.Element => {
   }, [popup]);
 
   return (
-    <div className="not-logged-in-profile" onClick={handleOpenOAuthPopup}>
+    <div
+      className="not-logged-in-profile"
+      onClick={handleOpenOAuthPopup}
+      data-cy={"login-btn"}
+    >
       <AccountCircleRoundedIcon
         className="not-logged-in-profile__image"
         fontSize="small"


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
<img width="100%" alt="스크린샷 2022-11-13 오후 2 48 36" src="https://user-images.githubusercontent.com/83356118/201507909-192b3d56-4a90-4271-8a81-d4f527084f59.png">

cypress 환경에서 vite 환경 변수를 사용하기 위해 cypress-vite를 설치하여 모듈을 전처리하였습니다.
- 로그인 버튼을 누르면 깃헙 화면이 보인다.
- 로그인 성공하면 프로필 사진이 보이고 로그아웃 성공하면 로그인 버튼이 보인다. 
라고 전제하고 테스트를 작성하였습니다.
# 연관 이슈
- related #53 
# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
    - 좋은 예시) feat [FE] : 깃허브 로그인 버튼 컴포넌트 구현 (#13)
    - 나쁜 예시) feat: 로그인 구현