### PR TITLE
기본적인 인피니티 스크롤 로딩 구현 (#60)

### DIFF
--- a/client/src/ReactRouter.tsx
+++ b/client/src/ReactRouter.tsx
@@ -1,13 +1,13 @@
 import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import LoginCallback from "@/components/LoginCallback/LoginCallback";
 import React from "react";
-import Profile from "@/components/Profile/Profile";
+import Main from "@/pages/Main";
 
 const ReactRouter = (): React.ReactElement => {
   const router = createBrowserRouter([
     {
       path: "/",
-      element: <Profile />,
+      element: <Main />,
     },
     {
       path: "/redirect/github",

--- a/client/src/apis/post.ts
+++ b/client/src/apis/post.ts
@@ -1,8 +1,12 @@
 import axiosInstance from "@/apis/axios";
 import { PostScroll } from "@/types/post";
 
-export const fetchPost = async (pageParam: number): Promise<PostScroll> => {
-  const { data } = await axiosInstance.get(`/api/posts?lastId=${pageParam}`);
-  console.log(data);
+export const fetchPost = async (
+  lastId: number,
+  size: number
+): Promise<PostScroll> => {
+  const { data } = await axiosInstance.get(
+    `/api/posts?lastId=${lastId}&size=${size}`
+  );
   return data;
 };

--- a/client/src/apis/post.ts
+++ b/client/src/apis/post.ts
@@ -1,0 +1,8 @@
+import axiosInstance from "@/apis/axios";
+import { PostScroll } from "@/types/post";
+
+export const fetchPost = async (pageParam: number): Promise<PostScroll> => {
+  const { data } = await axiosInstance.get(`/api/posts?lastId=${pageParam}`);
+  console.log(data);
+  return data;
+};

--- a/client/src/components/PostBar/Post/Post.tsx
+++ b/client/src/components/PostBar/Post/Post.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { PostInfo } from "@/types/post";
+
+interface PostProps {
+  postInfo: PostInfo;
+}
+
+const Post = ({ postInfo }: PostProps): JSX.Element => {
+  const { id, title, contents, imageUrls, user, tags, reviews } = postInfo;
+
+  return (
+    <div>
+      {`${id}, ${title}, ${contents}`}
+      {imageUrls.map((url) => `${url}`).join(",")}
+      {tags.map((tag) => `${tag}`).join(",")}
+      {user.id}
+      {reviews
+        .map(
+          (review) => `${review?.id}/${review?.user?.id}/${review?.contents}`
+        )
+        .join(",")}
+    </div>
+  );
+};
+
+export default Post;

--- a/client/src/components/PostBar/PostBar.scss
+++ b/client/src/components/PostBar/PostBar.scss
@@ -1,0 +1,5 @@
+.post-bar {
+  max-width: 540px;
+  height: 100rem;
+  background-color: red;
+}

--- a/client/src/components/PostBar/PostBar.tsx
+++ b/client/src/components/PostBar/PostBar.tsx
@@ -1,0 +1,43 @@
+import React, { Fragment } from "react";
+
+import "./PostBar.scss";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { fetchPost } from "@/apis/post";
+import Post from "@/components/PostBar/Post/Post";
+
+const PostBar = (): JSX.Element => {
+  const { data, status, fetchNextPage } = useInfiniteQuery(
+    ["posts"],
+    async ({ pageParam = 1 }) => await fetchPost(pageParam),
+    {
+      getNextPageParam: (lastPost, posts) => lastPost.lastId,
+    }
+  );
+
+  const fetchNext = (): void => {
+    fetchNextPage()
+      .then(() => {})
+      .catch((e) => {
+        console.log(e);
+      });
+  };
+
+  if (status === "loading") return <div>Loading...</div>;
+  if (status === "error") return <div>error...</div>;
+
+  return (
+    <>
+      목록:
+      {data?.pages.map((postScroll, index) => (
+        <Fragment key={index}>
+          {postScroll.posts.map((post) => {
+            return <Post key={post.id} postInfo={post} />;
+          })}
+        </Fragment>
+      ))}
+      <button onClick={fetchNext}>버튼</button>
+    </>
+  );
+};
+
+export default PostBar;

--- a/client/src/hooks/useIntersect.tsx
+++ b/client/src/hooks/useIntersect.tsx
@@ -1,0 +1,40 @@
+import { RefObject, useCallback, useEffect, useRef } from "react";
+
+type IntersectHandler = (
+  entry: IntersectionObserverEntry,
+  observer: IntersectionObserver
+) => void;
+
+/**
+ * root 원소와 target 원소가 교차 상태인지를 판단하여 조건에 만족할 경우
+ * callback 함수를 실행하는 target 원소의 Ref 를 반환합니다.
+ */
+const useIntersect = (
+  onIntersect: IntersectHandler,
+  options?: IntersectionObserverInit
+): RefObject<HTMLDivElement> => {
+  const ref = useRef<HTMLDivElement>(null);
+  const callback = useCallback(
+    (entries: IntersectionObserverEntry[], observer: IntersectionObserver) => {
+      entries.forEach((entry: IntersectionObserverEntry) => {
+        if (entry.isIntersecting) {
+          onIntersect(entry, observer);
+        }
+      });
+    },
+    [onIntersect]
+  );
+
+  useEffect(() => {
+    if (ref.current === null) {
+      return;
+    }
+    const observer = new IntersectionObserver(callback, options);
+    observer.observe(ref.current);
+    return () => observer.disconnect();
+  }, [ref, options, callback]);
+
+  return ref;
+};
+
+export default useIntersect;

--- a/client/src/hooks/usePostInfiniteScroll.tsx
+++ b/client/src/hooks/usePostInfiniteScroll.tsx
@@ -1,0 +1,67 @@
+import {
+  FetchNextPageOptions,
+  InfiniteData,
+  InfiniteQueryObserverResult,
+  QueryFunctionContext,
+  useInfiniteQuery,
+} from "@tanstack/react-query";
+import { fetchPost } from "@/apis/post";
+import { PostScroll } from "@/types/post";
+import { useCallback } from "react";
+
+interface PostInfiniteScrollOptions {
+  size: number;
+}
+
+interface PostInfiniteScrollResults {
+  data: InfiniteData<PostScroll> | undefined;
+  hasNextPage: boolean | undefined;
+  isFetching: boolean;
+  fetchNextPage: (
+    options?: FetchNextPageOptions | undefined
+  ) => Promise<InfiniteQueryObserverResult<PostScroll, unknown>>;
+  onIntersect: (
+    entry: IntersectionObserverEntry,
+    observer: IntersectionObserver
+  ) => void;
+}
+
+/**
+ * react-query 를 이용한 포스트 정보에 대한 인피니티 스크롤 커스텀 훅 입니다.
+ */
+const usePostInfiniteScroll = ({
+  size,
+}: PostInfiniteScrollOptions): PostInfiniteScrollResults => {
+  const { data, hasNextPage, isFetching, fetchNextPage } = useInfiniteQuery(
+    ["posts"],
+    async ({ pageParam = 0 }: QueryFunctionContext) =>
+      await fetchPost(pageParam, size),
+    {
+      getNextPageParam: (lastPost) =>
+        lastPost.isLast ? undefined : lastPost.lastId,
+    }
+  );
+
+  /**
+   * Intersection Observer 를 위한 콜백 함수
+   * 다음 페이지를 로딩해야 하는 상황을 감지했을 때 fetchPost 요청을 보내서 가져옵니다.
+   */
+  const onIntersect = useCallback(
+    (
+      entry: IntersectionObserverEntry,
+      observer: IntersectionObserver
+    ): void => {
+      observer.unobserve(entry.target);
+      if (hasNextPage === true && !isFetching) {
+        fetchNextPage()
+          .then(() => {})
+          .catch((e) => {});
+      }
+    },
+    [hasNextPage, isFetching, fetchNextPage]
+  );
+
+  return { data, hasNextPage, isFetching, fetchNextPage, onIntersect };
+};
+
+export default usePostInfiniteScroll;

--- a/client/src/mocks/handlers.ts
+++ b/client/src/mocks/handlers.ts
@@ -1,3 +1,4 @@
 import { authHandlers } from "@/mocks/handlers/authHandler";
+import { postHandlers } from "@/mocks/handlers/postHandler";
 
-export const handlers = [...authHandlers];
+export const handlers = [...authHandlers, ...postHandlers];

--- a/client/src/mocks/handlers/postHandler.ts
+++ b/client/src/mocks/handlers/postHandler.ts
@@ -26,16 +26,16 @@ const posts = Array.from(Array(1024).keys()).map(
 
 export const postHandlers = [
   rest.get(`${baseUrl}api/posts`, (req, res, ctx) => {
-    const lastId = req.url.searchParams.get("lastId");
-    const size = Number(lastId);
-    const isLast = posts.length >= size + 1;
+    const lastId = Number(req.url.searchParams.get("lastId"));
+    const size = Number(req.url.searchParams.get("size"));
+    const isLast = posts.length <= lastId + size;
 
     return res(
       ctx.status(200),
       ctx.delay(1000),
       ctx.json({
-        posts: posts.slice(size, size + 1),
-        lastId: size + 1,
+        posts: posts.slice(lastId, lastId + size),
+        lastId: lastId + size,
         isLast,
       })
     );

--- a/client/src/mocks/handlers/postHandler.ts
+++ b/client/src/mocks/handlers/postHandler.ts
@@ -1,0 +1,43 @@
+import { PostInfo } from "@/types/post";
+import { rest } from "msw";
+
+// Backend API Server URL
+const baseUrl = import.meta.env.VITE_API_SERVER_URL;
+
+const posts = Array.from(Array(1024).keys()).map(
+  (id): PostInfo => ({
+    id: `${id}`,
+    title: `title${id}`,
+    contents: `post_contents_${id}`,
+    imageUrls: [
+      "http://placeimg.com/640/640/animals",
+      "http://placeimg.com/640/640/animals",
+    ],
+    user: {
+      id: `${id + 10000}`,
+      username: `sampleUser_${id + 10000}`,
+      profileUrl: "http://placeimg.com/640/640/animals",
+      email: `name_${id + 10000}@gmail.com`,
+    },
+    tags: [`tag1`, `tag2`],
+    reviews: [],
+  })
+);
+
+export const postHandlers = [
+  rest.get(`${baseUrl}api/posts`, (req, res, ctx) => {
+    const lastId = req.url.searchParams.get("lastId");
+    const size = Number(lastId);
+    const isLast = posts.length >= size + 1;
+
+    return res(
+      ctx.status(200),
+      ctx.delay(1000),
+      ctx.json({
+        posts: posts.slice(size, size + 1),
+        lastId: size + 1,
+        isLast,
+      })
+    );
+  }),
+];

--- a/client/src/mocks/mockData.ts
+++ b/client/src/mocks/mockData.ts
@@ -1,4 +1,5 @@
 import { UserInfo } from "@/types/auth";
+import { Post } from "@/types/post";
 
 export const mockUser: UserInfo = {
   id: 1,
@@ -7,4 +8,22 @@ export const mockUser: UserInfo = {
   expiresIn: "1234555",
   email: "name@gmail.com",
   avatar_url: "http://placeimg.com/640/640/animals",
+};
+
+export const mockPost: Post = {
+  contents: "샘플 포스트 내용",
+  id: "10",
+  imageUrls: [
+    "http://placeimg.com/640/640/animals",
+    "http://placeimg.com/640/640/animals",
+  ],
+  reviews: [],
+  tags: ["tag1", "tag2"],
+  title: "샘플 포스트 제목",
+  user: {
+    id: "10000",
+    username: "sampleUser",
+    profileUrl: "http://placeimg.com/640/640/animals",
+    email: "name@gmail.com",
+  },
 };

--- a/client/src/pages/Main.tsx
+++ b/client/src/pages/Main.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import PostBar from "@/components/PostBar/PostBar";
+
+const Main = (): JSX.Element => {
+  return (
+    <>
+      <PostBar />
+    </>
+  );
+};
+
+export default Main;

--- a/client/src/types/post.ts
+++ b/client/src/types/post.ts
@@ -25,4 +25,5 @@ export interface PostInfo {
 export interface PostScroll {
   posts: PostInfo[];
   lastId: number;
+  isLast: boolean;
 }

--- a/client/src/types/post.ts
+++ b/client/src/types/post.ts
@@ -1,0 +1,28 @@
+// GET /api/post API 명세를 보고 만든 타입
+export interface User {
+  id: string;
+  username: string;
+  profileUrl: string;
+  email: string;
+}
+
+export interface Review {
+  id: string;
+  user: User;
+  contents: string;
+}
+
+export interface PostInfo {
+  id: string;
+  title: string;
+  contents: string;
+  imageUrls: string[];
+  user: User;
+  tags: string[];
+  reviews: Review[];
+}
+
+export interface PostScroll {
+  posts: PostInfo[];
+  lastId: number;
+}


### PR DESCRIPTION
# 요약

- 스크롤 바닥에 위치하면 다음 페이지가 5개씩(지정 가능) 로딩되도록 구현했습니다.
- 인피니티스크롤과 바닥을 감지하는 기능들을 커스텀 훅으로 분리했습니다.

# 연관 이슈

- related #60

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
    - 좋은 예시) feat [FE] : 깃허브 로그인 버튼 컴포넌트 구현 (#13)
    - 나쁜 예시) feat: 로그인 구현