### PR TITLE
dev main 브랜치 push 방지용 pre-push 훅 설정 

### DIFF
--- a/client/.husky/pre-push
+++ b/client/.husky/pre-push
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+FORBIDDEN_HTTPS_URL="https://github.com/boostcampwm-2022/web06-WeView.git"
+FORBIDDEN_SSH_URL="git@github.com:boostcampwm-2022/web06-WeView.git"
+FORBIDDEN_REF_MAIN="refs/heads/main"
+FORBIDDEN_REF_DEV="refs/heads/dev"
+
+remote="$1"
+url="$2"
+
+if [ "$url" != "$FORBIDDEN_HTTPS_URL" -a "$url" != "$FORBIDDEN_SSH_URL" ]
+then
+    echo "forked branch can push your commits"
+    exit 0 # Forked Project 에서는 제한하지 않음
+fi
+
+if read local_ref local_sha remote_ref remote_sha
+then
+  echo "현재 푸쉬하는 브랜치는 $local_ref 내부입니다."
+    if [ "$remote_ref" == "$FORBIDDEN_REF_MAIN" ] || [ "$remote_ref" == "$FORBIDDEN_REF_DEV" ]
+    then
+        echo "DO NOT PUSH TO MAIN OR DEV"
+        exit 1 # 금지된 ref 로 push 를 실행하면 에러
+    fi
+fi
+
+exit 0

--- a/client/package.json
+++ b/client/package.json
@@ -8,7 +8,7 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "test": "jest",
-    "prepare": "cd .. && husky install client/.husky",
+    "prepare": "chmod ug+x .husky/* && cd .. && husky install server/.husky",
     "checkTs": "tsc --noEmit"
   },
   "dependencies": {

--- a/server/.husky/pre-push
+++ b/server/.husky/pre-push
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+FORBIDDEN_HTTPS_URL="https://github.com/boostcampwm-2022/web06-WeView.git"
+FORBIDDEN_SSH_URL="git@github.com:boostcampwm-2022/web06-WeView.git"
+FORBIDDEN_REF_MAIN="refs/heads/main"
+FORBIDDEN_REF_DEV="refs/heads/dev"
+
+remote="$1"
+url="$2"
+
+if [ "$url" != "$FORBIDDEN_HTTPS_URL" -a "$url" != "$FORBIDDEN_SSH_URL" ]
+then
+    echo "forked branch can push your commits"
+    exit 0 # Forked Project 에서는 제한하지 않음
+fi
+
+if read local_ref local_sha remote_ref remote_sha
+then
+  echo "현재 푸쉬하는 브랜치는 $local_ref 내부입니다."
+    if [ "$remote_ref" == "$FORBIDDEN_REF_MAIN" ] || [ "$remote_ref" == "$FORBIDDEN_REF_DEV" ]
+    then
+        echo "DO NOT PUSH TO MAIN OR DEV"
+        exit 1 # 금지된 ref 로 push 를 실행하면 에러
+    fi
+fi
+
+exit 0

--- a/server/package.json
+++ b/server/package.json
@@ -19,7 +19,7 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "prepare": "cd .. && husky install server/.husky"
+    "prepare": "chmod ug+x .husky/* && cd .. && husky install server/.husky"
   },
   "dependencies": {
     "@nestjs/axios": "^1.0.0",


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
dev main 브랜치로 push 하는 실수를 방지하기 위해 dev main 브랜치에 push 방지용 pre push 훅을 설정해놓았습니다.
<img width="100%" alt="스크린샷 2022-11-16 오후 2 32 12" src="https://user-images.githubusercontent.com/83356118/202092109-64d3d8a5-cc6b-4a1f-9a1a-3c5e53562498.png">
해당 이미지는 test를 위해 브랜치를 현재 브랜치로 바꾸어 테스트해놓았고 현재 설정은 dev 브랜치와 main 브랜치에 적용돼있습니다.
# 연관 이슈
- related #79
# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
    - 좋은 예시) feat [FE] : 깃허브 로그인 버튼 컴포넌트 구현 (#13)
    - 나쁜 예시) feat: 로그인 구현