### PR TITLE
언어 선택에 따른 코드 하이라이팅 기능 및 xss 방지 기능 추가 

### DIFF
--- a/client/src/components/WriteModal/SnapShotNav/SnapShotNav.scss
+++ b/client/src/components/WriteModal/SnapShotNav/SnapShotNav.scss
@@ -4,20 +4,39 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  margin-left: 4rem;
-  width: 25%;
+  width: 40%;
   height: 100%;
   box-shadow: $box-shadow;
   border: 1px solid $line-color;
   border-radius: 0.25rem;
   overflow-y: auto;
+  overflow-x: hidden;
   &__item{
     margin: 1em 0;
+    width: 15em;
+    height: 15em;
     &--img{
       width: 15em;
       height: 15em;
-      border-radius: 1em;
+      border-radius: 0.25rem;
       cursor: pointer;
+      object-fit: cover;
+    }
+  }
+  @media screen and (max-width: 720px) {
+    flex-direction: row;
+    width: 100%;
+    height: 10rem;
+    overflow-y: hidden;
+    overflow-x: auto;
+    &__item{
+      width: 10rem;
+      height: 100%;
+      margin: 0 1em;
+      &--img{
+        width: 10rem;
+        height: 100%;
+      }
     }
   }
 }

--- a/client/src/components/WriteModal/SubmitModal/RegisterButton/RegisterButton.tsx
+++ b/client/src/components/WriteModal/SubmitModal/RegisterButton/RegisterButton.tsx
@@ -28,7 +28,7 @@ const RegisterButton = (): JSX.Element => {
       title,
       content,
       code,
-      language: "javascript",
+      language: language,
       images: images,
       tags: getHashTags(content),
     })

--- a/client/src/components/WriteModal/SubmitModal/RegisterButton/RegisterButton.tsx
+++ b/client/src/components/WriteModal/SubmitModal/RegisterButton/RegisterButton.tsx
@@ -4,11 +4,6 @@ import { getHashTags } from "@/utils/regExpression";
 import { postWritingsAPI } from "@/apis/post";
 import useModalStore from "@/store/useModalStore";
 
-const dummyImages = [
-  "https://images.unsplash.com/photo-1516259762381-22954d7d3ad2?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxzZWFyY2h8M3x8Y29kZXxlbnwwfHwwfHw%3D&auto=format&fit=crop&w=500&q=60",
-  "https://images.unsplash.com/photo-1576836165612-8bc9b07e7778?ixlib=rb-4.0.3&ixid=MnwxMjA3fDB8MHxzZWFyY2h8MTh8fGNvZGV8ZW58MHx8MHx8&auto=format&fit=crop&w=500&q=60",
-];
-
 const RegisterButton = (): JSX.Element => {
   const { title, language, code, content, images, resetWritingStore } =
     useWritingStore((state) => ({
@@ -34,7 +29,7 @@ const RegisterButton = (): JSX.Element => {
       content,
       code,
       language: "javascript",
-      images: [dummyImages[0]],
+      images: images,
       tags: getHashTags(content),
     })
       .then((res) => {

--- a/client/src/components/WriteModal/SubmitModal/RegisterButton/RegisterButton.tsx
+++ b/client/src/components/WriteModal/SubmitModal/RegisterButton/RegisterButton.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from "react";
 import useWritingStore from "@/store/useWritingStore";
-import { getHashTags } from "@/utils/regExpression";
+import { getHashTags, preventXSS } from "@/utils/regExpression";
 import { postWritingsAPI } from "@/apis/post";
 import useModalStore from "@/store/useModalStore";
 
@@ -27,7 +27,7 @@ const RegisterButton = (): JSX.Element => {
     postWritingsAPI({
       title,
       content,
-      code,
+      code: preventXSS(code),
       language: language,
       images: images,
       tags: getHashTags(content),

--- a/client/src/components/WriteModal/WriteModal.scss
+++ b/client/src/components/WriteModal/WriteModal.scss
@@ -18,13 +18,22 @@
   margin : 0 auto;
   width: 60%;
   max-width: 1080px;
+  min-width: 720px;
   height: calc(100% - 0.5rem);
   box-shadow: $button-shadow;
   transition: all 600ms cubic-bezier(0.86, 0, 0.3, 1);
   border-radius: 1rem;
   border: 0.25rem solid $line-color;
   z-index: 1;
+  @media screen and (max-width: 720px) {
+    width: 90%;
+    flex-direction: column;
+    overflow-y: scroll;
+    min-width: auto;
+  }
 }
+
+
 
 .open{
   top: 0;

--- a/client/src/components/WriteModal/WritingForm/CodeEditor/CodeEditor.scss
+++ b/client/src/components/WriteModal/WritingForm/CodeEditor/CodeEditor.scss
@@ -1,4 +1,5 @@
 @import "src/constants/library";
+@import "./CodeTheme.scss";
 
 .code-editor{
     position: relative;
@@ -6,6 +7,7 @@
     height: 90%;
     border-radius: 0.25rem;
   &__textarea, &__present {
+    color: $weview-white;
     font-size: 1.25rem;
     position: absolute;
     margin: 0;
@@ -22,8 +24,9 @@
     resize: none;
   }
   &__present{
-    z-index: 0;
     background-color: $codeblock-color;
+    color: #c9d1d9;
+    z-index: 0;
     border-radius: 0.25rem;
     text-overflow: ellipsis;
   }

--- a/client/src/components/WriteModal/WritingForm/CodeEditor/CodeEditor.tsx
+++ b/client/src/components/WriteModal/WritingForm/CodeEditor/CodeEditor.tsx
@@ -3,14 +3,15 @@ import useWritingStore from "@/store/useWritingStore";
 import hljs from "highlight.js";
 
 const CodeEditor = (): JSX.Element => {
-  const [highlightedCode, setHighlightedCode] = useState("");
-  const { code, setCode } = useWritingStore((state) => ({
+  const [highlightedHTML, setHighlightedHTML] = useState("");
+  const { code, setCode, language } = useWritingStore((state) => ({
     code: state.code,
     setCode: state.setCode,
+    language: state.language,
   }));
   useEffect(() => {
-    setHighlightedCode(
-      hljs.highlightAuto(code).value.replace(/" "/g, "&nbsp; ")
+    setHighlightedHTML(
+      hljs.highlight(code, { language }).value.replace(/" "/g, "&nbsp;")
     );
   }, [code]);
 
@@ -18,9 +19,12 @@ const CodeEditor = (): JSX.Element => {
     setCode(e.target.value);
   }, []);
 
-  const createMarkUpCode = (code: string): { __html: string } => ({
-    __html: code,
-  });
+  const createMarkUpCode = useCallback(
+    (code: string): { __html: string } => ({
+      __html: code,
+    }),
+    [code]
+  );
 
   return (
     <div className="code-editor">
@@ -33,7 +37,7 @@ const CodeEditor = (): JSX.Element => {
       />
       <pre className="code-editor__present">
         <code
-          dangerouslySetInnerHTML={createMarkUpCode(highlightedCode)}
+          dangerouslySetInnerHTML={createMarkUpCode(highlightedHTML)}
         ></code>
       </pre>
     </div>

--- a/client/src/components/WriteModal/WritingForm/CodeEditor/CodeTheme.scss
+++ b/client/src/components/WriteModal/WritingForm/CodeEditor/CodeTheme.scss
@@ -1,0 +1,124 @@
+/*!
+  Theme: GitHub Dark
+  Description: Dark theme as seen on github.com
+  Author: github.com
+  Maintainer: @Hirse
+  Updated: 2021-05-15
+  Outdated base version: https://github.com/primer/github-syntax-dark
+  Current colors taken from GitHub's CSS
+*/
+
+.hljs {
+
+  background: #0d1117;
+}
+
+.hljs-doctag,
+.hljs-keyword,
+.hljs-meta .hljs-keyword,
+.hljs-template-tag,
+.hljs-template-variable,
+.hljs-type,
+.hljs-variable.language_ {
+  /* prettylights-syntax-keyword */
+  color: #ff7b72;
+}
+
+.hljs-title,
+.hljs-title.class_,
+.hljs-title.class_.inherited__,
+.hljs-title.function_ {
+  /* prettylights-syntax-entity */
+  color: #d2a8ff;
+}
+
+.hljs-attr,
+.hljs-attribute,
+.hljs-literal,
+.hljs-meta,
+.hljs-number,
+.hljs-operator,
+.hljs-variable,
+.hljs-selector-attr,
+.hljs-selector-class,
+.hljs-selector-id {
+  /* prettylights-syntax-constant */
+  color: #79c0ff;
+}
+
+.hljs-regexp,
+.hljs-string,
+.hljs-meta .hljs-string {
+  /* prettylights-syntax-string */
+  color: #a5d6ff;
+}
+
+.hljs-built_in,
+.hljs-symbol {
+  /* prettylights-syntax-variable */
+  color: #ffa657;
+}
+
+.hljs-comment,
+.hljs-code,
+.hljs-formula {
+  /* prettylights-syntax-comment */
+  color: #8b949e;
+}
+
+.hljs-name,
+.hljs-quote,
+.hljs-selector-tag,
+.hljs-selector-pseudo {
+  /* prettylights-syntax-entity-tag */
+  color: #7ee787;
+}
+
+.hljs-subst {
+  /* prettylights-syntax-storage-modifier-import */
+  color: #c9d1d9;
+}
+
+.hljs-section {
+  /* prettylights-syntax-markup-heading */
+  color: #1f6feb;
+  font-weight: bold;
+}
+
+.hljs-bullet {
+  /* prettylights-syntax-markup-list */
+  color: #f2cc60;
+}
+
+.hljs-emphasis {
+  /* prettylights-syntax-markup-italic */
+  color: #c9d1d9;
+  font-style: italic;
+}
+
+.hljs-strong {
+  /* prettylights-syntax-markup-bold */
+  color: #c9d1d9;
+  font-weight: bold;
+}
+
+.hljs-addition {
+  /* prettylights-syntax-markup-inserted */
+  color: #aff5b4;
+  background-color: #033a16;
+}
+
+.hljs-deletion {
+  /* prettylights-syntax-markup-deleted */
+  color: #ffdcd7;
+  background-color: #67060c;
+}
+
+.hljs-char.escape_,
+.hljs-link,
+.hljs-params,
+.hljs-property,
+.hljs-punctuation,
+.hljs-tag {
+  /* purposely ignored */
+}

--- a/client/src/components/WriteModal/WritingForm/LanguageSelector/LanguageSelector.tsx
+++ b/client/src/components/WriteModal/WritingForm/LanguageSelector/LanguageSelector.tsx
@@ -1,11 +1,24 @@
-import React from "react";
+import React, { useCallback, ChangeEvent } from "react";
 import { LANGUAGES } from "@/constants/options";
 import ArrowDropDownOutlinedIcon from "@mui/icons-material/ArrowDropDownOutlined";
+import useWritingStore from "@/store/useWritingStore";
 
 const LanguageSelector = (): JSX.Element => {
+  const { selectedLanguage, setLanguage } = useWritingStore((state) => ({
+    selectedLanguage: state.language,
+    setLanguage: state.setLanguage,
+  }));
+  const selectLanguage = useCallback((e: ChangeEvent<HTMLSelectElement>) => {
+    setLanguage(e.target.value);
+  }, []);
+
   return (
     <div className="language">
-      <select className="language__select">
+      <select
+        onChange={selectLanguage}
+        className="language__select"
+        value={selectedLanguage}
+      >
         {LANGUAGES.map((language, idx) => (
           <option key={language} value={language}>
             {language}

--- a/client/src/components/WriteModal/WritingForm/WritingForm.scss
+++ b/client/src/components/WriteModal/WritingForm/WritingForm.scss
@@ -14,4 +14,8 @@
     display: flex;
     justify-content: flex-end;
   }
+  @media screen and (max-width: 720px){
+    height: 100%;
+    width: calc(100% - 4rem);
+  }
 }

--- a/client/src/constants/_library.scss
+++ b/client/src/constants/_library.scss
@@ -4,6 +4,7 @@ $placeholder-color: #BBBBBB;
 $codeblock-color: #292C33;
 $weview-white: #FFFFFF;
 $weview-off-white: #FCFCFC;
+$code-color: #C9D1D9;
 $primary: #84CB8D;
 $primary-light: #BED6C1;
 $alert: #EB923F;

--- a/client/src/constants/options.ts
+++ b/client/src/constants/options.ts
@@ -15,3 +15,5 @@ export const LANGUAGES = [
   "Swift",
   "Kotlin",
 ];
+
+export const DEFAULT_LANGUAGE = "JavaScript";

--- a/client/src/store/useWritingStore.ts
+++ b/client/src/store/useWritingStore.ts
@@ -1,5 +1,6 @@
 import create from "zustand";
 import { devtools, persist } from "zustand/middleware";
+import { DEFAULT_LANGUAGE } from "@/constants/options";
 
 interface WritingStates {
   title: string;
@@ -23,7 +24,7 @@ interface WritingActions {
 
 const initialWritingState: WritingStates = {
   title: "",
-  language: "",
+  language: DEFAULT_LANGUAGE,
   code: "",
   content: "",
   images: [],

--- a/client/src/utils/regExpression.ts
+++ b/client/src/utils/regExpression.ts
@@ -2,8 +2,14 @@ export const LINE_COUNT_REGEX = /\r\n|\r|\n/;
 
 export const FIND_ALL_HASH_TAG_REGEX = /#[^\s#]+/g;
 
+export const OPEN_TAG_REGEX = /</g;
+export const CLOSE_TAG_REGEX = />/g;
+
 export const getHashTags = (content: string): string[] | undefined =>
   content.match(FIND_ALL_HASH_TAG_REGEX)?.map((tag) => tag.slice(1));
 
 export const formatTag = (tag: string): string =>
   tag.replace(/_/g, "-").toLowerCase();
+
+export const preventXSS = (html: string): string =>
+  html.replace(OPEN_TAG_REGEX, "&lt;").replace(CLOSE_TAG_REGEX, "&gt;");


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
## [해당 Pull Request](https://github.com/boostcampwm-2022/web06-WeView/pull/124)의 병합을 먼저 해주시면 감사하겠습니다.

언어 선택에 맞추어 코드가 하이라이팅 될 수 있도록 수정하고 github-dark 테마를 적용하였습니다.
또 code는 기본적으로 다양한 script들을 사용할 가능성이 있다고 생각하여 react가 react dom을 만들 떄 기본적으로 escaping을 하지만 response를 복사해서 다른 웹에서 사용하는 것등을 고려해서 escaping을 추가하였습니다.

# 연관 이슈
- related #126

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
    - 좋은 예시) feat [FE] : 깃허브 로그인 버튼 컴포넌트 구현 (#13)
    - 나쁜 예시) feat: 로그인 구현