### PR TITLE
API 명세 변경에 따른 게시물 목록 조회 파라미터 수정

### DIFF
--- a/server/src/domain/post/dto/controller-request.dto.ts
+++ b/server/src/domain/post/dto/controller-request.dto.ts
@@ -63,15 +63,15 @@ export class InqueryDto {
   @Min(1, {
     message: '리뷰 개수 1개 이상부터 검색 가능합니다',
   }) //0인 경우는 해당 옵션을 쓸 필요가 없음
-  writtenAnswer?: number;
+  reviews?: number;
 
   @IsOptional()
   @Min(1, {
     message: '추천수 1개 이상부터 검색 가능합니다',
   }) //0인 경우는 해당 옵션을 쓸 필요가 없음
-  scores?: number;
+  likes?: number;
 
   @IsOptional()
   @Transform(({ value }) => value.trim())
-  search?: string;
+  detail?: string;
 }

--- a/server/src/domain/post/dto/controller-request.dto.ts
+++ b/server/src/domain/post/dto/controller-request.dto.ts
@@ -33,11 +33,12 @@ export class WriteDto {
 }
 
 export class InqueryDto {
+  @IsOptional()
   @IsInt()
   @Min(-1, {
     message: 'lastId는 -1과 Post의 인덱스만 입력 가능합니다',
   })
-  lastId: number;
+  lastId?: number = -1;
 
   @IsOptional()
   @IsString()

--- a/server/src/domain/post/dto/service-request.dto.ts
+++ b/server/src/domain/post/dto/service-request.dto.ts
@@ -7,17 +7,17 @@ export class LoadPostListRequestDto {
     tags: string[],
     authors: string[],
     category: Category,
-    writtenAnswer: number,
+    reviews: number,
     likesCnt: number,
-    search: string,
+    detail: string,
   ) {
     this.lastId = lastId;
     this.tags = tags;
     this.authors = authors;
     this.category = category;
-    this.writtenAnswer = writtenAnswer;
+    this.reviews = reviews;
     this.likesCnt = likesCnt;
-    this.search = search;
+    this.detail = detail;
   }
 
   @IsInt()
@@ -34,12 +34,12 @@ export class LoadPostListRequestDto {
   @IsOptional()
   @IsInt()
   @Min(1)
-  writtenAnswer?: number;
+  reviews?: number;
 
   @IsOptional()
   @Min(1)
   likesCnt?: number;
 
   @IsOptional()
-  search?: string;
+  detail?: string;
 }

--- a/server/src/domain/post/post.controller.ts
+++ b/server/src/domain/post/post.controller.ts
@@ -32,13 +32,7 @@ export class PostController {
   async inqueryUsingFilter(
     @Query() inqueryDto: InqueryDto,
   ): Promise<LoadPostListResponseDto> {
-    const {
-      lastId,
-      category,
-      writtenAnswer,
-      scores: likesCnt,
-      search,
-    } = inqueryDto;
+    const { lastId, category, reviews, likes: likesCnt, detail } = inqueryDto;
     let { authors, tags } = inqueryDto;
     // TODO 35-39 덜 깔끔해보임
     if (authors === undefined) {
@@ -54,9 +48,9 @@ export class PostController {
         tags,
         authors,
         category as Category,
-        writtenAnswer,
+        reviews,
         likesCnt,
-        search,
+        detail,
       ),
     );
   }

--- a/server/src/domain/post/post.repository.ts
+++ b/server/src/domain/post/post.repository.ts
@@ -76,14 +76,14 @@ export class PostRepository extends Repository<Post> {
     return filteringCnt !== 0;
   }
 
-  findBySearchWord(search: string): Promise<any[]> {
-    if (search === undefined || search.length < 0) {
+  findBySearchWord(detail: string): Promise<any[]> {
+    if (detail === undefined || detail.length < 0) {
       return null; //해당 조건은 사용하지 않습니다
     }
     return this.createQueryBuilder('post')
       .select('post.id', 'postId')
-      .where('post.title like :search OR post.content like :search', {
-        search: `%${search}%`,
+      .where('post.title like :detail OR post.content like :detail', {
+        detail: `%${detail}%`,
       })
       .getRawMany();
   }

--- a/server/src/domain/post/post.service.spec.ts
+++ b/server/src/domain/post/post.service.spec.ts
@@ -58,7 +58,7 @@ describe('PostService', () => {
       tags: ['java'],
       authors: [],
       category: Category.QUESTION,
-      writtenAnswer: 1,
+      reviews: 1,
       likesCnt: 1,
     };
     const resultFilteringLikesCnt = [

--- a/server/src/domain/post/post.service.ts
+++ b/server/src/domain/post/post.service.ts
@@ -103,13 +103,13 @@ export class PostService {
   async loadPostList(
     loadPostListRequestDto: LoadPostListRequestDto,
   ): Promise<LoadPostListResponseDto> {
-    const { lastId, tags, authors, category, writtenAnswer, likesCnt, search } =
+    const { lastId, tags, authors, category, reviews, likesCnt, detail } =
       loadPostListRequestDto;
     let isLast = true;
     const postInfosAfterFiltering = await Promise.all([
       this.postRepository.findByIdLikesCntGreaterThan(likesCnt),
       this.postToTagRepository.findByContainingTags(tags),
-      this.postRepository.findBySearchWord(search),
+      this.postRepository.findBySearchWord(detail),
     ]);
     const postIdsFiltered = this.returnPostIdByAllConditionPass(
       postInfosAfterFiltering,

--- a/server/test/post.e2e-spec.ts
+++ b/server/test/post.e2e-spec.ts
@@ -157,9 +157,9 @@ describe('Post e2e', () => {
           tags: '["sort", "greedy"]',
           authors: '["taehoon1229"]',
           category: 'question',
-          writtenAnswer: 3,
-          scores: 2,
-          search: '어떻게',
+          reviews: 3,
+          likes: 2,
+          detail: '어떻게',
         })
         .expect(200);
 
@@ -200,9 +200,9 @@ describe('Post e2e', () => {
           tags: '["sort", "greedy"]',
           authors: '["taehoon1229"]',
           category: 'question',
-          writtenAnswer: 3,
-          scores: 2,
-          search: '           어떻게            ',
+          reviews: 3,
+          likes: 2,
+          detail: '           어떻게            ',
         })
         .expect(200);
 


### PR DESCRIPTION
# 요약
파라미터 이름을 변경해주고, lastId에 기본값을 넣습니다

변경된 파라미터
- writtenAnswer -> reviews
- scores -> likes
- search -> detail

# 연관 이슈
- related #152 
# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
    - 좋은 예시) feat [FE] : 깃허브 로그인 버튼 컴포넌트 구현 (#13)
    - 나쁜 예시) feat: 로그인 구현