### PR TITLE
리뷰 작성 컴포넌트 구현 및 리뷰 Post 요청 API 적용 (#147)

### DIFF
--- a/client/src/apis/review.ts
+++ b/client/src/apis/review.ts
@@ -1,5 +1,5 @@
 import axiosInstance from "./axios";
-import { ReviewScroll } from "@/types/review";
+import { ReviewResponse, ReviewScroll } from "@/types/review";
 
 export const getReviewsAPI = async (
   postId: string,
@@ -8,5 +8,13 @@ export const getReviewsAPI = async (
   const { data } = await axiosInstance.get(
     `/posts/${postId}/reviews?lastId=${lastId}`
   );
+  return data;
+};
+
+export const postReviewAPI = async (
+  postId: string,
+  content: string
+): Promise<ReviewResponse> => {
+  const { data } = await axiosInstance.post(`/reviews`, { postId, content });
   return data;
 };

--- a/client/src/components/CommonButtons/CommonButtons.scss
+++ b/client/src/components/CommonButtons/CommonButtons.scss
@@ -1,26 +1,41 @@
-@import 'src/constants/_library.scss';
+@import "src/constants/_library.scss";
 
 @mixin weview-button {
   display: flex;
-  justify-content: center;
   align-items: center;
+  justify-content: center;
   width: 4.5rem;
   height: 2.3rem;
-  cursor: pointer;
-  font-size: 1rem;
   font-weight: normal;
+  font-size: 1rem;
   background: $weview-off-white;
   border-radius: 0.9em;
+  cursor: pointer;
+}
+
+@mixin weview-button--bold($width, $height) {
+  @include weview-button;
+  width: $width !important;
+  height: $height !important;
 }
 
 @mixin green-button {
   @include weview-button;
   color: $primary;
   border: 1px solid $primary;
-  &:hover{
-    background-color: $primary;
+  &:hover {
     color: $weview-off-white;
+    background-color: $primary;
   }
+}
+
+@mixin green-button--bold($width, $height) {
+  @include weview-button;
+  width: $width !important;
+  height: $height !important;
+  color: $weview-off-white;
+  background-color: $primary;
+  border: 1px solid $primary;
 }
 
 @mixin red-button {
@@ -28,22 +43,22 @@
   color: $error;
   border: 1px solid $error;
   &:hover {
-    background-color: $error;
     color: $weview-off-white;
+    background-color: $error;
   }
 }
 
-@mixin nav-button{
-  cursor: pointer;
+@mixin nav-button {
   width: 5rem;
-  font-size: 0.8rem;
   height: 1.8rem;
   margin-top: 1rem;
+  font-size: 0.8rem;
   background: none;
-  border-radius: 0.2rem;
   background: none;
   border: 1px solid $line-color;
-  &:focus{
+  border-radius: 0.2rem;
+  cursor: pointer;
+  &:focus {
     color: $line-color;
   }
 }

--- a/client/src/components/MainNav/Profile/NotLoggedInProfile/NotLoggedInProfile.tsx
+++ b/client/src/components/MainNav/Profile/NotLoggedInProfile/NotLoggedInProfile.tsx
@@ -1,50 +1,9 @@
-import React, { useEffect } from "react";
-import { githubLogInAPI } from "@/apis/auth";
-import useAuthStore from "@/store/useAuthStore";
+import React from "react";
 import useOAuthPopup from "@/hooks/useOAuthPopup";
 import AccountCircleOutlinedIcon from "@mui/icons-material/AccountCircleOutlined";
-import axiosInstance from "@/apis/axios";
 
 const NotLoggedInProfile = (): JSX.Element => {
-  const { popup, clearPopup, handleOpenOAuthPopup } = useOAuthPopup();
-  const login = useAuthStore((state) => state.login);
-
-  useEffect(() => {
-    if (popup === null) {
-      return;
-    }
-
-    /**
-     * 팝업 Window 에서 Github OAuth Authorization Code 전달 이벤트를
-     * 수신하여 처리하는 이벤트 리스너
-     */
-    const githubOAuthCodeListener = (e: MessageEvent<any>): void => {
-      // 동일한 Origin 의 이벤트만 처리하도록 제한
-      if (e.origin !== window.location.origin) {
-        return;
-      }
-      const { code } = e.data;
-
-      githubLogInAPI(code)
-        .then((userData) => {
-          login(userData);
-          axiosInstance.defaults.headers.common.Authorization = `Bearer ${userData.accessToken}`;
-        })
-        .catch((e) => {
-          console.log("서버에 요청을 보내는 데 실패했습니다.", e);
-        })
-        .finally(() => {
-          return clearPopup();
-        });
-    };
-
-    window.addEventListener("message", githubOAuthCodeListener, false);
-
-    return () => {
-      window.removeEventListener("message", githubOAuthCodeListener);
-      clearPopup();
-    };
-  }, [popup]);
+  const { handleOpenOAuthPopup } = useOAuthPopup();
 
   return (
     <>

--- a/client/src/components/Modal/ReviewModal/ReviewContainer/ReviewContainer.tsx
+++ b/client/src/components/Modal/ReviewModal/ReviewContainer/ReviewContainer.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from "react";
 import useReviewInfiniteScroll from "@/hooks/useReviewInfiniteScroll";
 import { ReviewInfo, ReviewScroll } from "@/types/review";
 import PostLoader from "@/components/PostBar/PostLoader/PostLoader";
+import ReviewForm from "@/components/Modal/ReviewModal/ReviewContainer/ReviewForm/ReviewForm";
 
 interface ReviewContainerProps {
   postId: string;
@@ -23,6 +24,7 @@ const ReviewContainer = ({ postId }: ReviewContainerProps): JSX.Element => {
         <div key={reviewInfo.id}>hi</div>
       ))}
       <PostLoader onIntersect={onIntersect} />
+      <ReviewForm postId={postId} />
     </div>
   );
 };

--- a/client/src/components/Modal/ReviewModal/ReviewContainer/ReviewForm/NotLoggedInReviewForm.tsx
+++ b/client/src/components/Modal/ReviewModal/ReviewContainer/ReviewForm/NotLoggedInReviewForm.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+import useOAuthPopup from "@/hooks/useOAuthPopup";
+
+const NotLoggedInReviewForm = (): JSX.Element => {
+  const { handleOpenOAuthPopup } = useOAuthPopup();
+
+  return (
+    <div className="not-logged-in-review-form">
+      <div>로그인이 필요합니다.</div>
+      <button
+        className="not-logged-in-review-form--login-button"
+        onClick={handleOpenOAuthPopup}
+      >
+        로그인
+      </button>
+    </div>
+  );
+};
+
+export default NotLoggedInReviewForm;

--- a/client/src/components/Modal/ReviewModal/ReviewContainer/ReviewForm/ReviewForm.scss
+++ b/client/src/components/Modal/ReviewModal/ReviewContainer/ReviewForm/ReviewForm.scss
@@ -1,0 +1,111 @@
+@import "@/constants/_library.scss";
+@import "@/components/CommonButtons/CommonButtons.scss";
+
+// 크기 관련
+$review-form-header-height: 1.5rem;
+$review-form-content-min-height: 5rem;
+$review-form-footer-height: 1.5rem;
+$review-form-padding: 0.5rem;
+$review-form-min-height: $review-form-header-height +
+  $review-form-content-min-height + $review-form-footer-height + 4 *
+  $review-form-padding;
+$review-form-max-height: $review-form-min-height +
+  $review-form-content-min-height;
+
+// 버튼
+$review-form-button-width: 3.5rem;
+
+$review-form-header-gap: 0.25rem;
+$review-form-radius: 0.35rem;
+$review-form-font-size: 0.75rem;
+
+@mixin review-form-common-style {
+  display: flex;
+  flex-direction: column;
+  gap: $review-form-padding;
+
+  box-sizing: border-box;
+
+  width: 100%;
+  height: fit-content;
+  min-height: $review-form-min-height;
+  max-height: $review-form-max-height;
+  padding: $review-form-padding;
+  font-size: $review-form-font-size;
+
+  background-color: $weview-off-white;
+  border: 2px solid $line-color;
+  border-radius: $review-form-radius;
+}
+
+.review-form {
+  @include review-form-common-style;
+
+  &__header {
+    display: flex;
+    gap: $review-form-header-gap;
+    align-items: center;
+
+    width: 100%;
+    height: $review-form-header-height;
+
+    &--profile-image {
+      height: 100%;
+      object-fit: contain;
+      border-radius: 50%;
+    }
+  }
+
+  &__content {
+    box-sizing: border-box;
+    width: 100%;
+    min-height: $review-form-content-min-height;
+    max-height: 2 * $review-form-content-min-height;
+    margin: 0;
+    padding: $review-form-padding;
+
+    // textarea 텍스트 스타일
+    font-size: $review-form-font-size;
+    font-family: GmarketSans;
+    border: 2px solid $line-color;
+    border-radius: $review-form-radius;
+    resize: vertical; // 세로로만 크기 변경 (최대 2배)
+
+    &:focus {
+      // 텍스트 입력 중일때 스타일 처리
+      border: 2px solid $primary;
+    }
+  }
+
+  &__footer {
+    display: flex;
+    flex-direction: row-reverse;
+
+    width: 100%;
+    height: $review-form-footer-height;
+
+    &--submit-button {
+      @include green-button--bold(
+        $review-form-button-width,
+        $review-form-footer-height
+      );
+      font-size: $review-form-font-size;
+    }
+  }
+}
+
+.not-logged-in-review-form {
+  @include review-form-common-style;
+  align-items: center;
+
+  // 콘텐츠 중앙 정렬
+  justify-content: center;
+
+  &--login-button {
+    @include weview-button--bold(
+      $review-form-button-width,
+      $review-form-footer-height
+    );
+    font-size: $review-form-font-size;
+  }
+}

--- a/client/src/components/Modal/ReviewModal/ReviewContainer/ReviewForm/ReviewForm.tsx
+++ b/client/src/components/Modal/ReviewModal/ReviewContainer/ReviewForm/ReviewForm.tsx
@@ -32,7 +32,6 @@ const ReviewForm = ({ postId }: ReviewFormProps): JSX.Element => {
     (e: SyntheticEvent): void => {
       e.preventDefault(); // 새로고침 방지
       if (content === "") {
-        console.log("empty content"); // 빈 문자열 방지
         return;
       }
       postReviewAPI(postId, content)

--- a/client/src/components/Modal/ReviewModal/ReviewContainer/ReviewForm/ReviewForm.tsx
+++ b/client/src/components/Modal/ReviewModal/ReviewContainer/ReviewForm/ReviewForm.tsx
@@ -1,0 +1,77 @@
+import React, {
+  ChangeEvent,
+  SyntheticEvent,
+  useCallback,
+  useState,
+} from "react";
+import { postReviewAPI } from "@/apis/review";
+import useAuthStore from "@/store/useAuthStore";
+import NotLoggedInReviewForm from "@/components/Modal/ReviewModal/ReviewContainer/ReviewForm/NotLoggedInReviewForm";
+
+interface ReviewFormProps {
+  postId: string;
+}
+
+const reviewTextAreaPlaceholder = "리뷰를 입력해주세요.";
+
+const ReviewForm = ({ postId }: ReviewFormProps): JSX.Element => {
+  const [myInfo, isLoggedIn] = useAuthStore((state) => [
+    state.myInfo,
+    state.isLoggedIn,
+  ]);
+  const [content, setContent] = useState("");
+
+  const handleContentChange = useCallback(
+    (e: ChangeEvent<HTMLTextAreaElement>): void => {
+      setContent(e.target.value);
+    },
+    [setContent]
+  );
+
+  const handleReviewSubmit = useCallback(
+    (e: SyntheticEvent): void => {
+      e.preventDefault(); // 새로고침 방지
+      if (content === "") {
+        console.log("empty content"); // 빈 문자열 방지
+        return;
+      }
+      postReviewAPI(postId, content)
+        .then((res) => console.log(res))
+        .catch((err) => console.log(err));
+    },
+    [content]
+  );
+
+  if (!isLoggedIn) {
+    return <NotLoggedInReviewForm />;
+  }
+
+  return (
+    <>
+      <form className="review-form" onSubmit={handleReviewSubmit}>
+        <div className="review-form__header">
+          <img
+            className="review-form__header--profile-image"
+            src={myInfo?.profileUrl}
+          />
+          <div className="review-form__header--username">
+            {myInfo?.nickname}
+          </div>
+        </div>
+        <textarea
+          className="review-form__content"
+          value={content}
+          onChange={handleContentChange}
+          placeholder={reviewTextAreaPlaceholder}
+        ></textarea>
+        <div className="review-form__footer">
+          <button className="review-form__footer--submit-button" type="submit">
+            제출
+          </button>
+        </div>
+      </form>
+    </>
+  );
+};
+
+export default ReviewForm;

--- a/client/src/components/Modal/ReviewModal/ReviewModal.scss
+++ b/client/src/components/Modal/ReviewModal/ReviewModal.scss
@@ -1,4 +1,5 @@
 @import "@/styles/_global-styles.scss";
+@import "ReviewContainer/ReviewForm/ReviewForm.scss";
 
 .review-modal {
   display: flex;
@@ -9,6 +10,6 @@
   &__review-container {
     width: 100%;
     max-width: $device-review-max-width;
-    background-color: yellow;
+    height: 100%;
   }
 }

--- a/client/src/hooks/useOAuthPopup.tsx
+++ b/client/src/hooks/useOAuthPopup.tsx
@@ -1,5 +1,8 @@
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { GITHUB_AUTH_SERVER_URL } from "@/constants/env";
+import { githubLogInAPI } from "@/apis/auth";
+import axiosInstance from "@/apis/axios";
+import useAuthStore from "@/store/useAuthStore";
 
 interface OAuthPopup {
   popup: Window | null;
@@ -8,6 +11,7 @@ interface OAuthPopup {
 }
 
 const useOAuthPopup = (): OAuthPopup => {
+  const login = useAuthStore((state) => state.login);
   const [popup, setPopup] = useState<Window | null>(null);
 
   // OAuth 팝업을 열어서 Github Authorization Code 를 요청합니다.
@@ -32,6 +36,44 @@ const useOAuthPopup = (): OAuthPopup => {
       popup.close();
     }
     setPopup(null);
+  }, [popup]);
+
+  // 로그인 팝입이 열리면 로그인 로직을 처리합니다.
+  useEffect(() => {
+    if (popup === null) {
+      return;
+    }
+
+    /**
+     * 팝업 Window 에서 Github OAuth Authorization Code 전달 이벤트를
+     * 수신하여 처리하는 이벤트 리스너
+     */
+    const githubOAuthCodeListener = (e: MessageEvent<any>): void => {
+      // 동일한 Origin 의 이벤트만 처리하도록 제한
+      if (e.origin !== window.location.origin) {
+        return;
+      }
+      const { code } = e.data;
+
+      githubLogInAPI(code)
+        .then((userData) => {
+          login(userData);
+          axiosInstance.defaults.headers.common.Authorization = `Bearer ${userData.accessToken}`;
+        })
+        .catch((e) => {
+          console.log("서버에 요청을 보내는 데 실패했습니다.", e);
+        })
+        .finally(() => {
+          return clearPopup();
+        });
+    };
+
+    window.addEventListener("message", githubOAuthCodeListener, false);
+
+    return () => {
+      window.removeEventListener("message", githubOAuthCodeListener);
+      clearPopup();
+    };
   }, [popup]);
 
   return { popup, clearPopup, handleOpenOAuthPopup };

--- a/client/src/types/review.ts
+++ b/client/src/types/review.ts
@@ -13,3 +13,7 @@ export interface ReviewScroll {
   lastId: number;
   isLast: boolean;
 }
+
+export interface ReviewResponse {
+  message: string;
+}


### PR DESCRIPTION
# 요약

![스크린샷 2022-11-24 오후 2 55 09](https://user-images.githubusercontent.com/63703962/203713003-6a72fcec-5e31-4133-b862-9af79960ada3.png)

- 로그인이 되지 않았을 시 로그인 요청 컴포넌트로 표시
- 로그인 되었을 시 맨 위에 프로필을 보여줌
- 텍스트 입력은 일단 기본 텍스트 입력만 지원, 세로로 크기 2배까지 조절 가능
- 제출 버튼 클릭 시 API 호출 (TODO: API 호출이 잘 되는걸 확인하고 progress를 표시한다거나, 전송 완료 시 content 부분을 초기화하는 부분 구현 예정)

# 연관 이슈

- related #147 

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
    - 좋은 예시) feat [FE] : 깃허브 로그인 버튼 컴포넌트 구현 (#13)
    - 나쁜 예시) feat: 로그인 구현