### PR TITLE
fix(FE): PostScroll 마지막 페이지 확인 후 Spinner 표시하는 기능 누락 수정 (#147)

### DIFF
--- a/client/src/components/PostScroll/PostScroll.tsx
+++ b/client/src/components/PostScroll/PostScroll.tsx
@@ -6,7 +6,7 @@ import usePostInfiniteScroll from "@/hooks/usePostInfiniteScroll";
 import ScrollLoader from "@/components/ScrollLoader/ScrollLoader";
 import { PostInfo, PostPages } from "@/types/post";
 const PostScroll = (): JSX.Element => {
-  const { data, onIntersect } = usePostInfiniteScroll();
+  const { data, onIntersect, hasNextPage } = usePostInfiniteScroll();
 
   // 포스트 바에 표시할 포스트 정보 목록
   const postInfos = useMemo(
@@ -20,7 +20,7 @@ const PostScroll = (): JSX.Element => {
       {postInfos.map((postInfo) => (
         <Post key={postInfo.id} postInfo={postInfo} />
       ))}
-      <ScrollLoader onIntersect={onIntersect} />
+      <ScrollLoader onIntersect={onIntersect} onLoad={hasNextPage} />
     </div>
   );
 };


### PR DESCRIPTION
# 요약

- PostScroll에서 바닥에 도착하면 더이상 로딩을 위한 Spinner가 보이지 않음 (이전 기능에서 추가했지만 PostScroll에 적용하지 않은 오류 수정)

# 연관 이슈

- related #147 
<!--이슈 번호를 적어주세요(예시: fix #123). -->

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
    - 좋은 예시) feat [FE] : 깃허브 로그인 버튼 컴포넌트 구현 (#13)
    - 나쁜 예시) feat: 로그인 구현