### PR TITLE
fix(BE): Swagger에서 refreshToken이 적용되지 않는 이슈 해결 (#228)

### DIFF
--- a/server/src/domain/likes/likes.controller.ts
+++ b/server/src/domain/likes/likes.controller.ts
@@ -26,7 +26,7 @@ import { UserNotFoundException } from '../../exception/user-not-found.exception'
 
 @Controller()
 @ApiTags('좋아요 API')
-@ApiBearerAuth('access-token')
+@ApiBearerAuth('accessToken')
 export class LikesController {
   constructor(private readonly likesService: LikesService) {}
 

--- a/server/src/domain/post/post.controller.ts
+++ b/server/src/domain/post/post.controller.ts
@@ -44,7 +44,7 @@ export const LATEST_DATA_CONDITION = -1;
 
 @Controller('posts')
 @ApiTags('게시물 API')
-@ApiBearerAuth('access-token')
+@ApiBearerAuth('accessToken')
 @ApiBadRequestResponse({ description: '잘못된 요청입니다' })
 export class PostController {
   constructor(

--- a/server/src/domain/report/report.controller.ts
+++ b/server/src/domain/report/report.controller.ts
@@ -28,7 +28,7 @@ import { PostNotFoundException } from '../../exception/post-not-found.exception'
 
 @Controller()
 @ApiTags('신고 API')
-@ApiBearerAuth('access-token')
+@ApiBearerAuth('accessToken')
 export class ReportController {
   constructor(private reportService: ReportService) {}
 

--- a/server/src/domain/review/review.controller.ts
+++ b/server/src/domain/review/review.controller.ts
@@ -33,7 +33,7 @@ import { PostNotFoundException } from '../../exception/post-not-found.exception'
 @Controller()
 @ApiTags('리뷰 API')
 @ApiBadRequestResponse({ description: '잘못된 요청입니다' })
-@ApiBearerAuth('access-token')
+@ApiBearerAuth('accessToken')
 export class ReviewController {
   constructor(private readonly reviewService: ReviewService) {}
 

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -29,7 +29,7 @@ async function bootstrap() {
     .addCookieAuth('refreshToken')
     .build();
   const document = SwaggerModule.createDocument(app, config);
-  SwaggerModule.setup('api', app, document);
+  SwaggerModule.setup('docs', app, document);
 
   app.useGlobalPipes(
     new ValidationPipe({


### PR DESCRIPTION
# 요약
토큰의 이름을 refresh-token에서 refreshToken으로 바꾸던 중, 누락된 부분들이 있어 Swagger가 인식하지 못하는 문제를 해결했습니다.

# 연관 이슈
- related #228 

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
    - 좋은 예시) feat [FE] : 깃허브 로그인 버튼 컴포넌트 구현 (#13)
    - 나쁜 예시) feat: 로그인 구현