### PR TITLE
스케쥴러 서버에 Swagger를 적용했습니다

### DIFF
--- a/scheduler-server/package.json
+++ b/scheduler-server/package.json
@@ -26,6 +26,7 @@
     "@nestjs/core": "^9.0.0",
     "@nestjs/platform-express": "^9.0.0",
     "@nestjs/schedule": "^2.1.0",
+    "@nestjs/swagger": "^6.1.3",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.13.2",
     "ioredis": "^5.2.4",

--- a/scheduler-server/src/main.ts
+++ b/scheduler-server/src/main.ts
@@ -1,9 +1,22 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { ValidationPipe } from '@nestjs/common';
+import { NestExpressApplication } from '@nestjs/platform-express';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+
+function setUpSwagger(app: NestExpressApplication) {
+  const config = new DocumentBuilder()
+    .setTitle('Weview Ranking API')
+    .setVersion('1.0')
+    .build();
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('/', app, document);
+}
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create<NestExpressApplication>(AppModule);
+
+  setUpSwagger(app);
 
   app.useGlobalPipes(
     new ValidationPipe({

--- a/scheduler-server/src/ranking/dto/controller-request.dto.ts
+++ b/scheduler-server/src/ranking/dto/controller-request.dto.ts
@@ -1,7 +1,13 @@
 import { Transform } from 'class-transformer';
 import { ArrayNotEmpty, IsOptional, IsString, Length } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
 
 export class SaveSearchedTagsDto {
+  @ApiProperty({
+    description: 'tag들을 콤마로 연결해 입력합니다 ex) java,greedy',
+    required: true,
+    type: String,
+  })
   @IsString({ each: true, message: '태그는 문자여야 합니다' })
   @Length(1, 15, {
     each: true,

--- a/scheduler-server/src/ranking/ranking.controller.ts
+++ b/scheduler-server/src/ranking/ranking.controller.ts
@@ -2,6 +2,8 @@ import {
   BadRequestException,
   Controller,
   Get,
+  HttpCode,
+  HttpStatus,
   InternalServerErrorException,
   Post,
   Query,
@@ -11,11 +13,17 @@ import { SaveSearchedTagsDto } from './dto/controller-request.dto';
 import { TagNameInvalidException } from '../exception/tag-name-invalid.exception';
 import { TagDuplicatedException } from '../exception/tag-duplicated.exception';
 import { TagCountInvalidException } from '../exception/tag-count-invalid.exception';
+import {
+  ApiBadRequestResponse,
+  ApiCreatedResponse,
+  ApiTags,
+} from '@nestjs/swagger';
 
 export const MAX_TAG_COUNT = 10;
 export const TAG_NAME_REGEX = /^[0-9|a-z|A-Z|ㄱ-ㅎ|가-힣]+$/;
 
 @Controller('ranking')
+@ApiTags('랭킹 API')
 export class RankingController {
   constructor(private readonly rankingService: RankingService) {}
 
@@ -25,6 +33,9 @@ export class RankingController {
   }
 
   @Post('tags')
+  @HttpCode(HttpStatus.CREATED)
+  @ApiCreatedResponse()
+  @ApiBadRequestResponse()
   async saveSearchedTags(@Query() saveSearchedTagsDto: SaveSearchedTagsDto) {
     try {
       const { names: tags } = saveSearchedTagsDto;


### PR DESCRIPTION
# 요약
스케쥴러 서버에 Swagger를 적용하고, 엔드포인트를 api/로 맞춰줬습니다.

- docker-compose 설정 
```
    swagger:
        image: swaggerapi/swagger-ui
        environment:
            - URLS=
              [
              {'localhost/api/-json',name:'Post'},
              {'localhost:8080/-json', name:'Ranking'},
              ]

```

# 연관 이슈
- related #286 
- 
# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
    - 좋은 예시) feat [FE] : 깃허브 로그인 버튼 컴포넌트 구현 (#13)
    - 나쁜 예시) feat: 로그인 구현