### PR TITLE
Ranking 서버의 RankingController url를 변경했습니다

### DIFF
--- a/scheduler-server/src/ranking/ranking.controller.ts
+++ b/scheduler-server/src/ranking/ranking.controller.ts
@@ -22,7 +22,7 @@ import {
 export const MAX_TAG_COUNT = 10;
 export const TAG_NAME_REGEX = /^[0-9|a-z|A-Z|ㄱ-ㅎ|가-힣]+$/;
 
-@Controller('ranking')
+@Controller()
 @ApiTags('랭킹 API')
 export class RankingController {
   constructor(private readonly rankingService: RankingService) {}


### PR DESCRIPTION
# 요약
랭킹 서버에서 ranking이라는 url이 하나 더 들어가는 게 Restful하지 않다 생각해,

기존 서버url/ranking/tags로 접근하던 방식에서 서버url/tags로 접근할 수 있게 url을 변경했습니다.

docker-compose 설정 변경
```
    swagger:
        image: swaggerapi/swagger-ui
        environment:
            - URLS=
              [
              {'localhost/api/-json',name:'Post'},
              {'localhost/api/ranking/-json', name:'Ranking'},
              ]
```

nGinx 설정 변경
```
  location /api/ranking/ {
    proxy_pass http://localhost:8080/;
  }
```

# 연관 이슈
- related #286 

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
    - 좋은 예시) feat [FE] : 깃허브 로그인 버튼 컴포넌트 구현 (#13)
    - 나쁜 예시) feat: 로그인 구현