### PR TITLE
인기 태그 클릭시 불러오기 기능 및 refetch 시간 15초로 조정

### DIFF
--- a/client/src/components/main/TagRanking/TagRankingItem/TagRankingItem.tsx
+++ b/client/src/components/main/TagRanking/TagRankingItem/TagRankingItem.tsx
@@ -1,7 +1,9 @@
-import React from "react";
+import React, { useCallback } from "react";
 import HorizontalRuleIcon from "@mui/icons-material/HorizontalRule";
 import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
 import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
+
+import useSearchStore from "@/store/useSearchStore";
 
 import "./TagRankingItem.scss";
 
@@ -14,8 +16,12 @@ interface PopularTagBoxProps {
 }
 
 const TagRankItem = ({ tagInfo }: PopularTagBoxProps): JSX.Element => {
+  const [updateQuery] = useSearchStore((state) => [state.updateQuery]);
+  const handleItemClick = useCallback((tagName: string): void => {
+    updateQuery({ tags: [tagName] });
+  }, []);
   return (
-    <li className="tag-rank-item">
+    <li onClick={() => handleItemClick(tagInfo.name)} className="tag-rank-item">
       <span className="tag-rank-item__rank">{tagInfo.nowRank}.</span>
       <span className="tag-rank-item__name">{tagInfo.name}</span>
       {/* 순위에 새로 들어온 태그 */}

--- a/client/src/hooks/useRanking.ts
+++ b/client/src/hooks/useRanking.ts
@@ -21,7 +21,7 @@ const useRanking = (): UseRanking => {
       refetchOnMount: true,
       refetchOnReconnect: true,
       refetchOnWindowFocus: true,
-      refetchInterval: 1000 * 10, // 10초
+      refetchInterval: 1000 * 15, // 15초
     }
   );
 


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
인기 태그 클릭시 불러오기 기능 및 refetch 시간 15초로 조정
# 연관 이슈
- related #292 

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
    - 좋은 예시) feat [FE] : 깃허브 로그인 버튼 컴포넌트 구현 (#13)
    - 나쁜 예시) feat: 로그인 구현