### PR TITLE
API 명세 변경에 따른 타입 변경 및 불필요한 코드 제거 (#289)

### DIFF
--- a/client/src/components/commons/SearchLabel/SearchLabel.scss
+++ b/client/src/components/commons/SearchLabel/SearchLabel.scss
@@ -61,7 +61,7 @@
     border: $border-x-small $reviews_color;
   }
 
-  &.detail {
+  &.details {
     @include hover-label($line-color);
     border: $border-x-small $line-color;
   }

--- a/client/src/components/main/PostScroll/Post/PostTitle/AuthorProfile/AuthorProfile.tsx
+++ b/client/src/components/main/PostScroll/Post/PostTitle/AuthorProfile/AuthorProfile.tsx
@@ -6,11 +6,6 @@ import "./AuthorProfile.scss";
 
 const AuthorProfile = (): JSX.Element => {
   const { author } = useContext(PostContext);
-  // const [isFollowing, setIsFollowing] = useState<boolean>(false);
-  //
-  // const toggleFollow = (): void => {
-  //   setIsFollowing((isFollowing) => !isFollowing);
-  // };
 
   return (
     <div className="post__title__author-profile">
@@ -21,14 +16,6 @@ const AuthorProfile = (): JSX.Element => {
       <div className="post__title__author-profile__username">
         {author.nickname}
       </div>
-      {/* <button */}
-      {/*  className={`post__title__author-profile__follow-button${ */}
-      {/*    isFollowing ? "--on" : "" */}
-      {/*  }`} */}
-      {/*  onClick={toggleFollow} */}
-      {/* > */}
-      {/*  {isFollowing ? "팔로우 취소" : "팔로잉"} */}
-      {/* </button> */}
     </div>
   );
 };

--- a/client/src/components/main/PostScroll/Post/PostTitle/CodeInfo/CodeInfo.tsx
+++ b/client/src/components/main/PostScroll/Post/PostTitle/CodeInfo/CodeInfo.tsx
@@ -1,17 +1,11 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, { useContext } from "react";
 
 import { PostContext } from "@/components/main/PostScroll/Post/Post";
-import { LINE_COUNT_REGEX } from "@/utils/regExpression";
 
 import "./CodeInfo.scss";
 
 const CodeInfo = (): JSX.Element => {
-  const { code, images } = useContext(PostContext);
-  const [lineCount, setLineCount] = useState(0);
-
-  useEffect(() => {
-    setLineCount(code.split(LINE_COUNT_REGEX).length);
-  }, [code]);
+  const { images, lineCount } = useContext(PostContext);
 
   return (
     <div className="post__title__code-info">

--- a/client/src/constants/defaultObject.ts
+++ b/client/src/constants/defaultObject.ts
@@ -1,6 +1,4 @@
-import { PostInfo, CodeInfo } from "@/types/post";
-
-import { DEFAULT_LANGUAGE } from "./options";
+import { PostInfo } from "@/types/post";
 
 export const defaultPostInfo: PostInfo = {
   author: {
@@ -9,21 +7,15 @@ export const defaultPostInfo: PostInfo = {
     profileUrl: "",
     email: "",
   },
-  category: "",
   code: "",
   content: "",
   id: "",
   images: [],
   language: "",
-  likes: 0,
+  lineCount: 0,
+  reviewCount: 0,
+  likeCount: 0,
   tags: [],
   title: "",
   updatedAt: "",
-};
-
-export const defaultCodeInfo: CodeInfo = {
-  code: "",
-  language: DEFAULT_LANGUAGE,
-  isEditable: false,
-  setCode: undefined,
 };

--- a/client/src/constants/search.ts
+++ b/client/src/constants/search.ts
@@ -1,22 +1,3 @@
 export const SEPARATOR: { [key: string]: string } = {
   "#": "tag",
-  "@": "category",
-  $: "author",
-  "+": "likes",
-  "^": "reviews",
 };
-
-interface Description {
-  example: string;
-  description: string;
-  type: string;
-}
-
-export const DESCRIPTION: Description[] = [
-  { example: "#알고리즘", description: "태그", type: "tag" },
-  { example: "$홍길동", description: "유저 닉네임", type: "author" },
-  { example: "@리뷰요청", description: "카테고리", type: "category" },
-  { example: "+3", description: "좋아요 개수", type: "likes" },
-  { example: "^5", description: "리뷰 개수", type: "reviews" },
-  { example: "합병 정렬", description: "상세 검색", type: "detail" },
-];

--- a/client/src/hooks/useLabel.ts
+++ b/client/src/hooks/useLabel.ts
@@ -1,55 +1,48 @@
 import { ChangeEvent, KeyboardEvent, useCallback, useState } from "react";
 
-import { Label, SearchQuery } from "@/types/search";
+import { Label, SearchFilter } from "@/types/search";
 import useSearchStore from "@/store/useSearchStore";
 import { isEnterKey } from "@/utils/pressedKeyCheck";
 import { SEPARATOR } from "@/constants/search";
 import { formatTag } from "@/utils/regExpression";
 import useLabelStore from "@/store/useLabelStore";
 
-const createSearchQuery = (inputLabels: Label[]): SearchQuery => {
-  return inputLabels.reduce(
-    (prev: SearchQuery, { type, value }: Label) => {
-      switch (type) {
-        case "tag":
-          prev.tags?.push(value);
-          break;
-        case "category":
-          prev.category = value;
-          break;
-        case "author":
-          prev.authors?.push(value);
-          break;
-        case "reviews":
-          prev.reviews = Number(value);
-          break;
-        case "likes":
-          prev.likes = Number(value);
-          break;
-        case "detail":
-          prev.detail = value;
-          break;
-      }
-      return prev;
-    },
-    {
-      lastId: "-1",
-      tags: [],
-      authors: [],
-      category: "",
-      reviews: 0,
-      likes: 0,
-      detail: "",
+const createSearchFilter = (inputLabels: Label[]): SearchFilter => {
+  const searchFilter: SearchFilter = {
+    lastId: "-1",
+    tags: [],
+    reviewCount: 0,
+    likeCount: 0,
+    details: [],
+  };
+
+  inputLabels.reduce((prev: SearchFilter, { type, value }: Label) => {
+    switch (type) {
+      case "tag":
+        prev.tags?.push(value);
+        break;
+      case "reviews":
+        prev.reviewCount = Number(value);
+        break;
+      case "likes":
+        prev.likeCount = Number(value);
+        break;
+      case "details":
+        prev.details?.push(value);
+        break;
     }
-  );
+    return prev;
+  }, searchFilter);
+
+  return searchFilter;
 };
 
 const createLabel = (word: string): Label => {
   const separator = word[0];
   const value = word.slice(1);
-  const type = SEPARATOR[separator] ?? "detail";
+  const type = SEPARATOR[separator] ?? "details";
 
-  if (type === "detail") {
+  if (type === "details") {
     // 상세 검색은 띄어쓰기를 포맷팅하지 않는다.
     return { type, value: word.trim() };
   }
@@ -107,7 +100,7 @@ const useLabel = (): UseLabelResult => {
 
   // PostScroll 에 현재 검색 필터를 적용
   const handleSubmit = (): void => {
-    const searchQuery = createSearchQuery(labels);
+    const searchQuery = createSearchFilter(labels);
     updateQuery(searchQuery);
   };
 

--- a/client/src/mocks/handlers/postHandler.ts
+++ b/client/src/mocks/handlers/postHandler.ts
@@ -2,11 +2,12 @@ import { rest } from "msw";
 
 import { API_SERVER_URL } from "@/constants/env";
 import { parsePostQueryString } from "@/mocks/utils/postUtils";
+import { PostInfo } from "@/types/post";
 
 // Backend API Server URL
 const baseUrl = API_SERVER_URL;
 
-const posts = Array.from(Array(1024).keys()).map((id) => ({
+const posts: PostInfo[] = Array.from(Array(1024).keys()).map((id) => ({
   id: `${id}`,
   title: `제목_${id}`,
   content: `내용_${id}`,
@@ -27,36 +28,42 @@ const posts = Array.from(Array(1024).keys()).map((id) => ({
     email: `name_${id + 10000}@gmail.com`,
   },
   tags: [`tag1`, `tag2`, id % 2 === 0 ? `테그` : `태그`],
-  reviews: Array.from(Array(id % 3).keys()),
+  reviewCount: id % 10,
+  likeCount: id % 10,
+  lineCount: 1,
   updatedAt: "2022-11-16 12:26:56.124939",
   code: `sourcecode: ~~~~~~~~~~~~~~~~~~`,
   language: `javascript`,
   category: id % 2 === 0 ? "리뷰요청" : "질문",
-  likes: id % 10,
   isLiked: id % 2 === 0,
 }));
 
 export const postHandler = [
   rest.get(`${baseUrl}/posts`, (req, res, ctx) => {
     const lastId = Number(req.url.searchParams.get("lastId")) + 1;
-    const { tags, authors, category, reviews, likes, detail } =
-      parsePostQueryString(req.url);
+    const { tags, reviewCount, likeCount, details } = parsePostQueryString(
+      req.url
+    );
     const SIZE = 3;
     const filteredData = posts
       .filter(
         (post) =>
+          tags === undefined ||
           tags.length === 0 ||
           post.tags.some((postTag) => tags.includes(postTag))
       )
-      .filter(
-        (post) => authors.length === 0 || authors.includes(post.author.nickname)
-      )
-      .filter((post) => category === "" || category === post.category)
-      .filter((post) => reviews <= post.reviews.length)
-      .filter((post) => likes <= (post.likes ?? 0))
+      .filter((post) => (reviewCount ?? 0) <= post.reviewCount)
+      .filter((post) => (likeCount ?? 0) <= post.likeCount)
       .filter(
         (post) =>
-          post.title.search(detail) > -1 || post.content.search(detail) > -1
+          details === undefined ||
+          details.length === 0 ||
+          details.some(
+            (detail) =>
+              post.title.search(detail) > -1 ||
+              post.content.search(detail) > -1 ||
+              post.author.nickname.search(detail) > -1
+          )
       );
     const isLast = filteredData.length <= lastId + SIZE;
 

--- a/client/src/mocks/utils/postUtils.ts
+++ b/client/src/mocks/utils/postUtils.ts
@@ -1,13 +1,12 @@
-import { SearchQuery } from "@/types/search";
+import { SearchFilter } from "@/types/search";
 
-export const parsePostQueryString = (url: URL): any => {
-  const searchQuery: SearchQuery = {
+export const parsePostQueryString = (url: URL): SearchFilter => {
+  const searchQuery: SearchFilter = {
+    lastId: "-1",
     tags: [],
-    authors: [],
-    category: "",
-    reviews: 0,
-    likes: 0,
-    detail: "",
+    reviewCount: 0,
+    likeCount: 0,
+    details: [],
   };
 
   const tags = url.searchParams.get("tags");
@@ -15,22 +14,16 @@ export const parsePostQueryString = (url: URL): any => {
     searchQuery.tags?.push(...decodeURI(tags).split(","));
   }
 
-  const authors = url.searchParams.get("authors");
-  if (authors !== null) {
-    searchQuery.authors?.push(...decodeURI(authors).split(","));
-  }
-
-  const category = url.searchParams.get("category") ?? "";
-  searchQuery.category = decodeURI(category);
-
   const reviews = url.searchParams.get("reviews") ?? "0";
-  searchQuery.reviews = Number(decodeURI(reviews));
+  searchQuery.reviewCount = Number(decodeURI(reviews));
 
   const likes = url.searchParams.get("likes") ?? "0";
-  searchQuery.likes = Number(decodeURI(likes));
+  searchQuery.likeCount = Number(decodeURI(likes));
 
-  const detail = url.searchParams.get("detail") ?? "";
-  searchQuery.detail = decodeURI(detail);
+  const details = url.searchParams.get("details");
+  if (details !== null) {
+    searchQuery.details = decodeURI(details).split(",");
+  }
 
   return searchQuery;
 };

--- a/client/src/store/useSearchStore.ts
+++ b/client/src/store/useSearchStore.ts
@@ -1,14 +1,14 @@
 import create from "zustand";
 import { devtools } from "zustand/middleware";
 
-import { SearchQuery } from "@/types/search";
+import { SearchFilter } from "@/types/search";
 
 interface SearchStates {
-  searchQuery: SearchQuery;
+  searchQuery: SearchFilter;
 }
 
 interface SearchActions {
-  updateQuery: (query: SearchQuery) => void;
+  updateQuery: (query: SearchFilter) => void;
   reset: () => void;
 }
 

--- a/client/src/types/post.ts
+++ b/client/src/types/post.ts
@@ -1,50 +1,37 @@
 // GET /api/post API 명세를 보고 만든 타입
 import { PreSignedData, UserInfo } from "@/types/auth";
+import { InfiniteScrollResponse } from "@/types/react-query";
 
 export interface Image {
   src: string;
   name: string;
 }
 
-interface AdditionalPostInfo {
-  category?: string;
-  likes?: number;
-  isLiked?: boolean;
+export interface UploadImageProps {
+  preSignedData: PreSignedData;
+  imageUri: string;
 }
 
-export interface CodeStore {
-  code: string;
-  language: string;
-  setCode?: (code: string) => void;
-}
-
-export interface CodeInfo extends CodeStore {
-  isEditable: boolean;
-}
-
-export interface PostInfo extends AdditionalPostInfo {
+export interface PostInfo {
   id: string;
   title: string;
   content: string;
   code: string;
   language: string;
-  images: Image[];
-  updatedAt: string;
-  author: UserInfo;
   tags: string[];
+  images: Image[];
+  author: UserInfo;
+  updatedAt: string;
+  reviewCount: number;
+  likeCount: number;
+  lineCount: number;
+  isLiked?: boolean;
 }
 
-export interface PostPages {
+export interface PostPages extends InfiniteScrollResponse {
   posts: PostInfo[];
-  lastId: number;
-  isLast: boolean;
 }
 
 export interface WritingResponse {
   message: string;
-}
-
-export interface UploadImageProps {
-  preSignedData: PreSignedData;
-  imageUri: string;
 }

--- a/client/src/types/react-query.ts
+++ b/client/src/types/react-query.ts
@@ -1,0 +1,8 @@
+export interface InfiniteScrollRequest {
+  lastId: string;
+}
+
+export interface InfiniteScrollResponse {
+  lastId: string;
+  isLast: boolean;
+}

--- a/client/src/types/review.ts
+++ b/client/src/types/review.ts
@@ -1,17 +1,17 @@
 import { UserInfo } from "@/types/auth";
+import { InfiniteScrollResponse } from "@/types/react-query";
+
+export interface ReviewerInfo extends UserInfo {}
 
 export interface ReviewInfo {
   id: string;
-  reviewer: Reviewer;
+  reviewer: ReviewerInfo;
   content: string;
   updatedAt: string;
 }
-export interface Reviewer extends UserInfo {}
 
-export interface ReviewPages {
+export interface ReviewPages extends InfiniteScrollResponse {
   reviews: ReviewInfo[];
-  lastId: number;
-  isLast: boolean;
 }
 
 export interface ReviewResponse {

--- a/client/src/types/search.ts
+++ b/client/src/types/search.ts
@@ -1,14 +1,21 @@
+import { InfiniteScrollRequest } from "@/types/react-query";
+
 export interface Label {
   type: string;
   value: string;
 }
 
-export interface SearchQuery {
-  lastId?: string;
+export interface SearchFilter extends InfiniteScrollRequest {
+  details?: string[];
   tags?: string[];
-  authors?: string[];
-  category?: string;
-  reviews?: number;
-  likes?: number;
-  detail?: string;
+  likeCount?: number;
+  reviewCount?: number;
+}
+
+export interface BookmarkSearchFilter extends InfiniteScrollRequest {
+  postId: string;
+}
+
+export interface AuthorSearchFilter extends InfiniteScrollRequest {
+  userId: string;
 }

--- a/client/src/utils/queryString.ts
+++ b/client/src/utils/queryString.ts
@@ -1,7 +1,7 @@
 import { isQueryTypeFine } from "@/utils/typeCheck";
-import { SearchQuery } from "@/types/search";
+import { SearchFilter } from "@/types/search";
 
-export const setQueryString = (searchingObj: SearchQuery): string =>
+export const setQueryString = (searchingObj: SearchFilter): string =>
   Object.entries(searchingObj)
     .filter(([key, value]) => key === "lastId" || isQueryTypeFine(value))
     .map(([key, value]) => {


### PR DESCRIPTION
# 요약

- 검색 및 Post 요청 등 명세 변경에 따른 타입 변경 및 적용
- MOCK API 적용
- 검색 details 여러개를 쉼표로 구분해서 전송
- 로컬에서 MOCK API로 실행되는 부분은 확인했습니다.

![image](https://user-images.githubusercontent.com/63703962/205584852-7f27766c-6c7d-4098-b6ce-5fef911e2d7c.png)

# 연관 이슈

- related #289 
<!--이슈 번호를 적어주세요(예시: fix #123). -->

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
    - 좋은 예시) feat [FE] : 깃허브 로그인 버튼 컴포넌트 구현 (#13)
    - 나쁜 예시) feat: 로그인 구현