### PR TITLE
특정 사용자의 게시물을 조회하는 기능을 구현했습니다

### DIFF
--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -6,6 +6,7 @@ import { PostModule } from './domain/post/post.module';
 import { ReviewModule } from './domain/review/review.module';
 import { LikesModule } from './domain/likes/likes.module';
 import { ReportModule } from './domain/report/report.module';
+import { UserModule } from './domain/user/user.module';
 
 @Module({
   imports: [
@@ -32,6 +33,7 @@ import { ReportModule } from './domain/report/report.module';
     ReviewModule,
     LikesModule,
     ReportModule,
+    UserModule,
   ],
 })
 export class AppModule {}

--- a/server/src/domain/post/post.repository.ts
+++ b/server/src/domain/post/post.repository.ts
@@ -109,4 +109,12 @@ export class PostRepository extends Repository<Post> {
       .where('id=:id', { id: post.id })
       .execute();
   }
+
+  findByUserId(lastId: number, userId: number) {
+    return this.createQueryBuilder('post')
+      .where('post.userId = :userId', { userId: userId })
+      .take(SEND_POST_CNT + 1)
+      .orderBy('post.id', 'DESC')
+      .getMany();
+  }
 }

--- a/server/src/domain/user/dto/controller-request.dto.ts
+++ b/server/src/domain/user/dto/controller-request.dto.ts
@@ -1,0 +1,16 @@
+import { IsInt, IsOptional, Min } from 'class-validator';
+import { Type } from 'class-transformer';
+
+export class UserInqueryPostDto {
+  /**
+   * lastId를 기준으로 더 최신의 데이터를 반환합니다.
+   * lastId를 입력하지 않으면 가장 최신의 데이터를 반환합니다
+   */
+  @IsOptional()
+  @Type(() => Number)
+  @IsInt()
+  @Min(-1, {
+    message: 'lastId는 -1과 Post의 인덱스만 입력 가능합니다',
+  })
+  lastId?: number = -1;
+}

--- a/server/src/domain/user/user.controller.ts
+++ b/server/src/domain/user/user.controller.ts
@@ -1,0 +1,47 @@
+import {
+  BadRequestException,
+  Controller,
+  Get,
+  NotFoundException,
+  Param,
+  Query,
+  Req,
+} from '@nestjs/common';
+import { Request } from 'express';
+import { UserService } from './user.service';
+import {
+  ApiBadRequestResponse,
+  ApiNotFoundResponse,
+  ApiOkResponse,
+  ApiTags,
+} from '@nestjs/swagger';
+import { UserInqueryPostDto } from './dto/controller-request.dto';
+import { UserNotFoundException } from '../../exception/user-not-found.exception';
+
+@Controller('users')
+@ApiTags('사용자 API')
+export class UserController {
+  constructor(private readonly userService: UserService) {}
+
+  /**
+   * 특정 사용자가 작성한 게시물을 최신 순으로 가져옵니다
+   */
+  @Get(':userId/posts')
+  @ApiOkResponse()
+  @ApiNotFoundResponse()
+  @ApiBadRequestResponse()
+  async inqueryPosts(
+    @Req() req: Request,
+    @Param('userId') userId: number,
+    @Query() requestDto: UserInqueryPostDto,
+  ) {
+    try {
+      const { lastId } = requestDto;
+      return await this.userService.inqueryPosts(lastId, userId);
+    } catch (err) {
+      if (err instanceof UserNotFoundException) {
+        throw new NotFoundException(err.message);
+      }
+    }
+  }
+}

--- a/server/src/domain/user/user.module.ts
+++ b/server/src/domain/user/user.module.ts
@@ -1,0 +1,11 @@
+import { UserController } from './user.controller';
+import { UserService } from './user.service';
+import { Module } from '@nestjs/common';
+import { PostRepository } from '../post/post.repository';
+import { UserRepository } from './user.repository';
+
+@Module({
+  controllers: [UserController],
+  providers: [UserService, UserRepository, PostRepository],
+})
+export class UserModule {}

--- a/server/src/domain/user/user.service.spec.ts
+++ b/server/src/domain/user/user.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { UserService } from './user.service';
+
+describe('UserService', () => {
+  let service: UserService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [UserService],
+    }).compile();
+
+    service = module.get<UserService>(UserService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/server/src/domain/user/user.service.spec.ts
+++ b/server/src/domain/user/user.service.spec.ts
@@ -1,18 +1,82 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { UserService } from './user.service';
+import { UserRepository } from './user.repository';
+import { PostRepository } from '../post/post.repository';
+import { DataSource } from 'typeorm';
+import { User } from './user.entity';
+import { Post } from '../post/post.entity';
+import { LoadPostListResponseDto } from '../post/dto/service-response.dto';
+import { PostToTag } from '../post-to-tag/post-to-tag.entity';
+import { Tag } from '../tag/tag.entity';
+import { UserNotFoundException } from '../../exception/user-not-found.exception';
 
 describe('UserService', () => {
   let service: UserService;
+  let userRepository;
+  let postRepository;
+  let post;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [UserService],
+      providers: [
+        UserService,
+        UserRepository,
+        PostRepository,
+        {
+          provide: DataSource,
+          useValue: {
+            createEntityManager: () => jest.fn(),
+          },
+        },
+      ],
     }).compile();
 
     service = module.get<UserService>(UserService);
+    userRepository = module.get<UserRepository>(UserRepository);
+    postRepository = module.get<PostRepository>(PostRepository);
+
+    post = new Post();
+    post.id = 1;
+    post.title = '제목';
+    post.content = 'content';
+    post.code = 'System.out.println("zz")';
+    post.language = 'java';
+    post.updatedAt = new Date();
+    post.user = new User();
+    post.lineCount = 1;
+    const pt = new PostToTag();
+    const tag = new Tag();
+    tag.name = 'dd';
+    pt.tag = tag;
+    post.postToTags = [pt];
   });
 
-  it('should be defined', () => {
-    expect(service).toBeDefined();
+  describe('특정 사용자의 게시물 조회', () => {
+    it('4개를 반환하면 isLast는 false가 된다', async () => {
+      userRepository.findOneBy = jest.fn().mockResolvedValue(new User());
+      postRepository.findByUserId = jest
+        .fn()
+        .mockResolvedValue([post, post, post, post]);
+
+      expect((await service.inqueryPosts(1, 1)).isLast).toBeFalsy();
+    });
+
+    it('4개보다 작은 값을 반환하면 isLast는 true가 된다', async () => {
+      userRepository.findOneBy = jest.fn().mockResolvedValue(new User());
+      postRepository.findByUserId = jest
+        .fn()
+        .mockResolvedValue([post, post, post]);
+      expect((await service.inqueryPosts(1, 1)).isLast).toBeTruthy();
+    });
+
+    it('존재하지 않는 사용자가 입력되면 UserNotFound 예외를 반환한다', async () => {
+      try {
+        userRepository.findOneBy = jest.fn().mockResolvedValue(null);
+        expect(await service.inqueryPosts(1, 1));
+        throw new Error();
+      } catch (err) {
+        expect(err).toBeInstanceOf(UserNotFoundException);
+      }
+    });
   });
 });

--- a/server/src/domain/user/user.service.ts
+++ b/server/src/domain/user/user.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@nestjs/common';
+import { PostRepository } from '../post/post.repository';
+import { SEND_POST_CNT } from '../post/post.controller';
+import { LoadPostListResponseDto } from '../post/dto/service-response.dto';
+import { UserRepository } from './user.repository';
+import { UserNotFoundException } from '../../exception/user-not-found.exception';
+
+@Injectable()
+export class UserService {
+  constructor(
+    private readonly userRepository: UserRepository,
+    private readonly postRepository: PostRepository,
+  ) {}
+
+  async inqueryPosts(lastId: number, userId: number) {
+    let isLast = true;
+
+    const user = await this.userRepository.findOneBy({
+      id: userId,
+    });
+    if (!user) {
+      throw new UserNotFoundException();
+    }
+
+    const result = await this.postRepository.findByUserId(lastId, userId);
+    if (this.canGetNextPost(result.length)) {
+      result.pop();
+      isLast = false;
+    }
+    return new LoadPostListResponseDto(result, isLast);
+  }
+
+  private canGetNextPost(resultCnt: number) {
+    return resultCnt === SEND_POST_CNT + 1;
+  }
+}


### PR DESCRIPTION
# 요약
존재하는 사용자의 게시물만 조회가 가능합니다.

무한 스크롤 방식을 사용해 게시물의 조회가 일어납니다

# 연관 이슈
- related #299 

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
    - 좋은 예시) feat [FE] : 깃허브 로그인 버튼 컴포넌트 구현 (#13)
    - 나쁜 예시) feat: 로그인 구현