### PR TITLE
feat(FE): 최근 검색 기록 최대 5개만 가져오기, 기록 제거 버튼 기능 구현 (#280)

### DIFF
--- a/client/src/apis/search.ts
+++ b/client/src/apis/search.ts
@@ -8,11 +8,9 @@ import { MAX_SEARCH_HISTORY } from "@/constants/search";
 export const fetchSearchHistory = async (): Promise<SearchHistory[]> => {
   const { data } = await axiosInstance.get(`/search/histories`);
   if (!Array.isArray(data)) {
-    console.log("hi", data);
     return [];
   }
   if (data.length > MAX_SEARCH_HISTORY) {
-    console.log(data.length);
     return data.slice(0, 5);
   }
   return data;

--- a/client/src/apis/search.ts
+++ b/client/src/apis/search.ts
@@ -1,10 +1,23 @@
 import axiosInstance from "@/apis/axios";
 import { SearchHistory } from "@/types/search";
+import { MAX_SEARCH_HISTORY } from "@/constants/search";
 
 /**
  * 사용자의 최근 검색어를 요청하는 함수
  */
 export const fetchSearchHistory = async (): Promise<SearchHistory[]> => {
   const { data } = await axiosInstance.get(`/search/histories`);
+  if (!Array.isArray(data)) {
+    console.log("hi", data);
+    return [];
+  }
+  if (data.length > MAX_SEARCH_HISTORY) {
+    console.log(data.length);
+    return data.slice(0, 5);
+  }
   return data;
+};
+
+export const deleteSearchHistory = async (id: string): Promise<void> => {
+  await axiosInstance.delete(`/search/histories/${id}`);
 };

--- a/client/src/components/main/MainNav/NavContent/SearchContent/SearchHistoryView/SearchHistoryView.tsx
+++ b/client/src/components/main/MainNav/NavContent/SearchContent/SearchHistoryView/SearchHistoryView.tsx
@@ -4,10 +4,11 @@ import RemoveIcon from "@mui/icons-material/Remove";
 
 import { Label, SearchHistory } from "@/types/search";
 import { QUERY_KEYS } from "@/react-query/queryKeys";
-import { fetchSearchHistory } from "@/apis/search";
+import { deleteSearchHistory, fetchSearchHistory } from "@/apis/search";
 import { labelsFrom } from "@/utils/label";
 import SearchLabel from "@/components/commons/SearchLabel/SearchLabel";
 import useLabel from "@/hooks/useLabel";
+import { queryClient } from "@/react-query/queryClient";
 
 import "./SearchHistoryView.scss";
 
@@ -21,6 +22,16 @@ const SearchHistoryItem = ({
   onClick,
 }: SearchHistoryItemProps): JSX.Element => {
   const labels = labelsFrom(history);
+  const handleItemDelete = (): void => {
+    void (async () => {
+      await deleteSearchHistory(history.id);
+      await queryClient.refetchQueries({
+        queryKey: [QUERY_KEYS.HISTORY],
+        type: "active",
+      });
+    })();
+  };
+
   return (
     <div className="search-content__body__histories--item">
       <span
@@ -34,7 +45,10 @@ const SearchHistoryItem = ({
           />
         ))}
       </span>
-      <RemoveIcon className="search-content__body__histories--item--remove" />
+      <RemoveIcon
+        className="search-content__body__histories--item--remove"
+        onClick={handleItemDelete}
+      />
     </div>
   );
 };
@@ -53,7 +67,7 @@ const SearchHistoryView = (): JSX.Element => {
     <div className="search-content__body__histories">
       {data?.map((history) => (
         <SearchHistoryItem
-          key={history.updatedAt}
+          key={history.id}
           history={history}
           onClick={loadLabels}
         />

--- a/client/src/constants/search.ts
+++ b/client/src/constants/search.ts
@@ -1,3 +1,5 @@
 export const SEPARATOR: { [key: string]: string } = {
   "#": "tags",
 };
+
+export const MAX_SEARCH_HISTORY = 5;

--- a/client/src/mocks/datasource/mockDataSource.ts
+++ b/client/src/mocks/datasource/mockDataSource.ts
@@ -59,4 +59,10 @@ export const rankingData = [
   { name: "kotlin", prev: 13 },
 ];
 
-export const history: SearchHistory[] = [];
+export let history: SearchHistory[];
+history = [];
+
+// lint: import 한 변수에 직접 할당 불가 오류 해결을 위한 함수
+export const setHistory = (newHistory: SearchHistory[]): void => {
+  history = newHistory;
+};

--- a/client/src/mocks/handlers/postHandler.ts
+++ b/client/src/mocks/handlers/postHandler.ts
@@ -7,6 +7,8 @@ import { posts, history } from "@/mocks/datasource/mockDataSource";
 // Backend API Server URL
 const baseUrl = API_SERVER_URL;
 
+let id = 0;
+
 export const postHandler = [
   rest.get(`${baseUrl}/posts`, (req, res, ctx) => {
     const lastId = Number(req.url.searchParams.get("lastId")) + 1;
@@ -38,11 +40,12 @@ export const postHandler = [
 
     history.push({
       author: "mock-user",
-      details: details ?? [],
-      likeCount: likeCount ?? 0,
-      reviewCount: reviewCount ?? 0,
-      tags: tags ?? [],
+      details: details ?? null,
+      likeCount: likeCount ?? null,
+      reviewCount: reviewCount ?? null,
+      tags: tags ?? null,
       updatedAt: Date(),
+      id: String(++id),
     });
 
     return res(

--- a/client/src/mocks/handlers/searchHandler.ts
+++ b/client/src/mocks/handlers/searchHandler.ts
@@ -1,7 +1,7 @@
 import { rest } from "msw";
 
 import { API_SERVER_URL } from "@/constants/env";
-import { history } from "@/mocks/datasource/mockDataSource";
+import { history, setHistory } from "@/mocks/datasource/mockDataSource";
 
 // Backend API Server URL
 const baseUrl = API_SERVER_URL;
@@ -9,5 +9,11 @@ const baseUrl = API_SERVER_URL;
 export const searchHandler = [
   rest.get(`${baseUrl}/search/histories`, (req, res, ctx) => {
     return res(ctx.status(200), ctx.delay(1000), ctx.json(history));
+  }),
+  rest.delete(`${baseUrl}/search/histories/:id`, (req, res, ctx) => {
+    setHistory(
+      history.filter((searchHistory) => searchHistory.id !== req.params.id)
+    );
+    return res(ctx.status(204), ctx.delay(1000));
   }),
 ];

--- a/client/src/types/search.ts
+++ b/client/src/types/search.ts
@@ -27,4 +27,5 @@ export interface SearchHistory {
   reviewCount: number | null;
   likeCount: number | null;
   updatedAt: string;
+  id: string;
 }


### PR DESCRIPTION
# 요약

- 검색 최대 개수 제한 (상수로 관리)
- 기록 제거 기능 구현
- 관련 MOCK API수정

# 연관 이슈
- related #280 
<!--이슈 번호를 적어주세요(예시: fix #123). -->

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
    - 좋은 예시) feat [FE] : 깃허브 로그인 버튼 컴포넌트 구현 (#13)
    - 나쁜 예시) feat: 로그인 구현