### PR TITLE
fix(BE): 상세 검색시 각 검색어가 AND 연산이 일어나도록 수정 (#314)

### DIFF
--- a/server/src/domain/post/post.repository.ts
+++ b/server/src/domain/post/post.repository.ts
@@ -74,6 +74,23 @@ export class PostRepository extends Repository<Post> {
     return filteringCnt !== 0;
   }
 
+  async deleteUsingPost(post: Post) {
+    await this.createQueryBuilder()
+      .update(Post)
+      .set(post)
+      .where('id=:id', { id: post.id })
+      .execute();
+  }
+
+  findByUserId(lastId: number, userId: number) {
+    return this.createQueryBuilder('post')
+      .where('post.userId = :userId', { userId: userId })
+      .take(SEND_POST_CNT + 1)
+      .orderBy('post.id', 'DESC')
+      .getMany();
+  }
+
+  //
   findBySearchWords(details: string[]) {
     if (!details || details.length <= 0) {
       return null; //해당 조건은 사용하지 않습니다
@@ -93,14 +110,6 @@ export class PostRepository extends Repository<Post> {
     return queryBuilder.getRawMany();
   }
 
-  async deleteUsingPost(post: Post) {
-    await this.createQueryBuilder()
-      .update(Post)
-      .set(post)
-      .where('id=:id', { id: post.id })
-      .execute();
-  }
-
   async findByAuthorNicknames(nicknames: string[]) {
     return this.createQueryBuilder('post')
       .innerJoinAndSelect('post.user', 'user')
@@ -109,11 +118,14 @@ export class PostRepository extends Repository<Post> {
       .getRawMany();
   }
 
-  findByUserId(lastId: number, userId: number) {
-    return this.createQueryBuilder('post')
-      .where('post.userId = :userId', { userId: userId })
-      .take(SEND_POST_CNT + 1)
-      .orderBy('post.id', 'DESC')
-      .getMany();
+  async filterUsingDetail(detail: string) {
+    const queryBuilder = this.createQueryBuilder('p')
+      .innerJoinAndSelect('p.user', 'u')
+      .select('p.id', 'postId')
+      .where(
+        'u.nickname=:nickname OR p.title like :detail OR p.content like :detail',
+        { nickname: detail, detail: `%${detail}%` },
+      );
+    return queryBuilder.getRawMany();
   }
 }

--- a/server/src/domain/post/post.service.ts
+++ b/server/src/domain/post/post.service.ts
@@ -77,6 +77,9 @@ export class PostService {
     return Promise.all(postToTagEntityPromises);
   }
 
+  /**
+   * 게시물을 조회한다
+   */
   async loadPostList(
     loadPostListRequestDto: LoadPostListRequestDto,
   ): Promise<LoadPostListResponseDto> {
@@ -112,36 +115,13 @@ export class PostService {
     likeCount: number,
     details: string[],
   ) {
-    const detailedSearchResult = await this.filterUsingDetails(details);
-
     const postsThatPassEachFilter = await Promise.all([
       this.postRepository.findByIdLikesCntGreaterThanOrEqual(likeCount),
       this.postToTagRepository.findByContainingTags(tags),
       this.postRepository.findByReviewCntGreaterThanOrEqual(reviewCount),
-      detailedSearchResult,
+      this.filterUsingDetails(details),
     ]);
-
     return this.mergeFilterResult(postsThatPassEachFilter);
-  }
-
-  private async filterUsingDetails(details: string[]) {
-    if (!details || details.length === 0) {
-      return null;
-    }
-
-    const results = await Promise.all([
-      this.postRepository.findBySearchWords(details),
-      this.postRepository.findByAuthorNicknames(details),
-    ]);
-    return this.getResultsAfterRemovedDuplicated(results);
-  }
-
-  private getResultsAfterRemovedDuplicated(results: any[][]) {
-    const temp = new Set();
-    for (const result of results) {
-      result.forEach((each) => temp.add(each));
-    }
-    return Array.from(temp);
   }
 
   /**
@@ -187,5 +167,44 @@ export class PostService {
     }
     post.isDeleted = true;
     await this.postRepository.deleteUsingPost(post);
+  }
+
+  private async filterUsingDetails(details: string[]) {
+    if (!details || details.length < 1) {
+      return null;
+    }
+    const postsFilteringEachDetail = await Promise.all(
+      details.map((detail) => this.postRepository.filterUsingDetail(detail)),
+    );
+
+    const temp = [];
+    for (const posts of postsFilteringEachDetail) {
+      temp.push(posts.map((post) => post.postId));
+    }
+    return this.findIntersection(temp);
+  }
+
+  private findIntersection(bundles: any[][]) {
+    const result = [];
+    let smallestBundle = bundles[0];
+    for (const post of bundles) {
+      if (smallestBundle.length > post.length) {
+        smallestBundle = post;
+      }
+    }
+
+    for (const postId of smallestBundle) {
+      let isIntersect = true;
+      for (const bundle of bundles) {
+        if (!bundle.includes(postId)) {
+          isIntersect = false;
+          break;
+        }
+      }
+      if (isIntersect) {
+        result.push({ postId: postId });
+      }
+    }
+    return result;
   }
 }


### PR DESCRIPTION
# 요약
각각의 검색어에 대해 AND 연산이 일어납니다.

상세 검색 시 필터링할 수 있는 속성은 제목, 내용, 작성자의 이름입니다.

각각의 검색어는 제목, 내용에 포함되는지, 동일한 작성자의 이름이 있는지 검색합니다.
각각의 검색어는 AND 연산이 일어나, 조건이 많아질수록 세세한 검색이 가능하도록 합니다.

각각의 조건을 만족하는 게시물들을 구한 뒤, 교집합을 사용해 상세 검색 조건을 다 만족하는 게시물만을 검색합니다.

# 연관 이슈
- related #314 

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
    - 좋은 예시) feat [FE] : 깃허브 로그인 버튼 컴포넌트 구현 (#13)
    - 나쁜 예시) feat: 로그인 구현