### PR TITLE
게시물 단건 조회 기능을 구현했습니다.

### DIFF
--- a/server/src/domain/post/post.controller.ts
+++ b/server/src/domain/post/post.controller.ts
@@ -197,6 +197,7 @@ export class PostController {
       if (err instanceof PostNotFoundException) {
         throw new NotFoundException(err.message);
       }
+      throw new InternalServerErrorException();
     }
   }
 }

--- a/server/src/domain/post/post.controller.ts
+++ b/server/src/domain/post/post.controller.ts
@@ -181,4 +181,22 @@ export class PostController {
       throw new InternalServerErrorException();
     }
   }
+
+  /**
+   * 게시물 한 건을 조회합니다
+   */
+  @Get(':postId')
+  @ApiOkResponse({ description: '올바른 요청입니다' })
+  @ApiNotFoundResponse({
+    description: '유저 혹은 게시물이 존재하지 않습니다',
+  })
+  async inqueryPost(@Param('postId') postId: number) {
+    try {
+      return await this.postService.inqueryPost(postId);
+    } catch (err) {
+      if (err instanceof PostNotFoundException) {
+        throw new NotFoundException(err.message);
+      }
+    }
+  }
 }

--- a/server/src/domain/post/post.repository.ts
+++ b/server/src/domain/post/post.repository.ts
@@ -116,4 +116,14 @@ export class PostRepository extends Repository<Post> {
       .orderBy('post.id', 'DESC')
       .getMany();
   }
+
+  async findById(postId: number) {
+    return this.createQueryBuilder('post')
+      .innerJoinAndSelect('post.user', 'user')
+      .leftJoinAndSelect('post.postToTags', 'postToTag')
+      .leftJoinAndSelect('postToTag.tag', 'tag')
+      .leftJoinAndSelect('post.images', 'image')
+      .where('post.id = :postId', { postId: postId })
+      .getOne();
+  }
 }

--- a/server/src/domain/post/post.service.spec.ts
+++ b/server/src/domain/post/post.service.spec.ts
@@ -13,6 +13,7 @@ import { PostNotFoundException } from '../../exception/post-not-found.exception'
 import { UserNotSameException } from '../../exception/user-not-same.exception';
 import { Post } from './post.entity';
 import { Tag } from '../tag/tag.entity';
+import { PostToTag } from '../post-to-tag/post-to-tag.entity';
 
 describe('PostService', () => {
   let service: PostService;
@@ -691,6 +692,56 @@ describe('PostService', () => {
       try {
         postRepository.findOne = jest.fn(() => null);
         await service.delete(1, 1);
+        throw new Error();
+      } catch (err) {
+        expect(err).toBeInstanceOf(PostNotFoundException);
+      }
+    });
+  });
+
+  describe('게시물 한 건 조회', () => {
+    let post;
+    beforeEach(() => {
+      post = new Post();
+      post.id = 1;
+      post.title = '제목';
+      post.content = 'content';
+      post.code = 'System.out.println("zz")';
+      post.language = 'java';
+      post.updatedAt = new Date();
+      post.user = new User();
+      post.lineCount = 1;
+      const pt = new PostToTag();
+      const tag = new Tag();
+      tag.name = 'dd';
+      pt.tag = tag;
+      post.postToTags = [pt];
+    });
+    it('(성공) 게시물이 있는 경우', async () => {
+      post.isDeleted = false;
+      postRepository.findById = jest.fn(() => post);
+
+      await service.inqueryPost(1);
+    });
+
+    it('(실패) 게시물이 없는 경우', async () => {
+      try {
+        postRepository.findById = jest.fn(() => null);
+
+        await service.inqueryPost(1);
+
+        throw new Error();
+      } catch (err) {
+        expect(err).toBeInstanceOf(PostNotFoundException);
+      }
+    });
+
+    it('(실패) 게시물이 삭제된 경우', async () => {
+      try {
+        post.isDeleted = true;
+        postRepository.findById = jest.fn(() => post);
+
+        await service.inqueryPost(1);
         throw new Error();
       } catch (err) {
         expect(err).toBeInstanceOf(PostNotFoundException);

--- a/server/src/domain/post/post.service.ts
+++ b/server/src/domain/post/post.service.ts
@@ -2,7 +2,10 @@ import { Injectable } from '@nestjs/common';
 import { Post } from './post.entity';
 import { Image } from '../image/image.entity';
 import { Tag } from '../tag/tag.entity';
-import { LoadPostListResponseDto } from './dto/service-response.dto';
+import {
+  EachPostResponseDto,
+  LoadPostListResponseDto,
+} from './dto/service-response.dto';
 import { PostToTag } from '../post-to-tag/post-to-tag.entity';
 import { PostRepository } from './post.repository';
 import { PostToTagRepository } from '../post-to-tag/post-to-tag.repository';
@@ -187,5 +190,14 @@ export class PostService {
     }
     post.isDeleted = true;
     await this.postRepository.deleteUsingPost(post);
+  }
+
+  async inqueryPost(postId: number) {
+    const post = await this.postRepository.findById(postId);
+
+    if (!post || post.isDeleted) {
+      throw new PostNotFoundException();
+    }
+    return new EachPostResponseDto(post);
   }
 }

--- a/server/src/domain/user/user.controller.ts
+++ b/server/src/domain/user/user.controller.ts
@@ -2,6 +2,7 @@ import {
   Controller,
   Get,
   HttpStatus,
+  InternalServerErrorException,
   NotFoundException,
   Param,
   Query,
@@ -47,6 +48,7 @@ export class UserController {
       if (err instanceof UserNotFoundException) {
         throw new NotFoundException(err.message);
       }
+      throw new InternalServerErrorException();
     }
   }
 


### PR DESCRIPTION
# 요약
게시물을 단건으로 조회합니다.

<img width="1058" alt="스크린샷 2022-12-06 오전 5 03 52" src="https://user-images.githubusercontent.com/67636607/205732378-1483573c-7bac-41d1-a123-c56b9879e285.png">

# 연관 이슈
- related #317 
# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
    - 좋은 예시) feat [FE] : 깃허브 로그인 버튼 컴포넌트 구현 (#13)
    - 나쁜 예시) feat: 로그인 구현