### PR TITLE
GET /users/{userId}/posts 시 연관관계를 가져오지 않는 이슈를 해결했습니다

### DIFF
--- a/server/src/domain/post/dto/service-response.dto.ts
+++ b/server/src/domain/post/dto/service-response.dto.ts
@@ -34,10 +34,9 @@ export class EachPostResponseDto {
     this.content = post.content;
     this.code = post.code;
     this.language = post.language;
-    if (post.images === undefined) {
-      post.images = [];
-    }
-    this.images = post.images.map((image) => new EachImageResponseDto(image));
+    this.images = (post.images ?? []).map(
+      (image) => new EachImageResponseDto(image),
+    );
     this.updatedAt = post.updatedAt;
     this.author = new AuthorDto(post.user);
     this.tags = post.postToTags.map((obj) => obj.tag.name);

--- a/server/src/domain/post/post.repository.ts
+++ b/server/src/domain/post/post.repository.ts
@@ -84,38 +84,14 @@ export class PostRepository extends Repository<Post> {
 
   findByUserId(lastId: number, userId: number) {
     return this.createQueryBuilder('post')
+      .leftJoinAndSelect('post.user', 'user')
+      .leftJoinAndSelect('post.postToTags', 'postToTag')
+      .leftJoinAndSelect('postToTag.tag', 'tag')
+      .leftJoinAndSelect('post.images', 'image')
       .where('post.userId = :userId', { userId: userId })
       .take(SEND_POST_CNT + 1)
       .orderBy('post.id', 'DESC')
       .getMany();
-  }
-
-  //
-  findBySearchWords(details: string[]) {
-    if (!details || details.length <= 0) {
-      return null; //해당 조건은 사용하지 않습니다
-    }
-    const queryBuilder = this.createQueryBuilder('post').select(
-      'post.id',
-      'postId',
-    );
-    for (const detail of details) {
-      queryBuilder.orWhere(
-        'post.title like :detail OR post.content like :detail',
-        {
-          detail: `%${detail}%`,
-        },
-      );
-    }
-    return queryBuilder.getRawMany();
-  }
-
-  async findByAuthorNicknames(nicknames: string[]) {
-    return this.createQueryBuilder('post')
-      .innerJoinAndSelect('post.user', 'user')
-      .select('post.id', 'postId')
-      .where('user.nickname in (:nicknames)', { nicknames: nicknames })
-      .getRawMany();
   }
 
   async filterUsingDetail(detail: string) {

--- a/server/src/domain/post/post.service.spec.ts
+++ b/server/src/domain/post/post.service.spec.ts
@@ -291,7 +291,7 @@ describe('PostService', () => {
         .spyOn(postToTagRepository, 'findByContainingTags')
         .mockResolvedValue(resultFilteringTag);
       jest
-        .spyOn(postRepository, 'findBySearchWords')
+        .spyOn(postRepository, 'filterUsingDetail')
         .mockResolvedValue(resultFilteringTag);
       jest
         .spyOn(postRepository, 'findByReviewCntGreaterThanOrEqual')


### PR DESCRIPTION
# 요약
`GET /users/{userId}/posts` 시 연관관계를 가져오지 않는 이슈를 해결했습니다

innerJoin을 하지 않아 연관관계를 가져오지 않는 이슈였습니다.

# 연관 이슈
- related #321 
# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
    - 좋은 예시) feat [FE] : 깃허브 로그인 버튼 컴포넌트 구현 (#13)
    - 나쁜 예시) feat: 로그인 구현