### PR TITLE
fix(FE): Search 요청이 완료된 이후 History 요청이 되지 않던 오류 해결 (#347)

### DIFF
--- a/client/src/components/main/MainNav/NavContent/SearchContent/SearchContentHeader/SearchContentHeader.tsx
+++ b/client/src/components/main/MainNav/NavContent/SearchContent/SearchContentHeader/SearchContentHeader.tsx
@@ -6,6 +6,7 @@ import ArrowDropDownCircleSharpIcon from "@mui/icons-material/ArrowDropDownCircl
 import useLabel from "@/hooks/useLabel";
 import { Label } from "@/types/search";
 import SearchLabel from "@/components/commons/SearchLabel/SearchLabel";
+import useNav from "@/hooks/useNav";
 
 import DetailSearchForm from "./DetailSearchForm/DetailSearchForm";
 
@@ -20,6 +21,7 @@ const SearchContentHeader = (): JSX.Element => {
     removeLabel,
     handleSubmit,
   } = useLabel();
+  const { handleNavClose } = useNav();
   const [isDetailOpened, setIsDetailOpened] = useState(false);
 
   return (
@@ -36,7 +38,9 @@ const SearchContentHeader = (): JSX.Element => {
         />
         <SearchIcon
           className="search-content__form__submit"
-          onClick={handleSubmit}
+          onClick={() => {
+            handleNavClose(() => handleSubmit());
+          }}
         />
       </div>
       <div className="search-content__filter__header">

--- a/client/src/components/main/MainNav/NavContent/SearchContent/SearchHistoryView/SearchHistoryView.tsx
+++ b/client/src/components/main/MainNav/NavContent/SearchContent/SearchHistoryView/SearchHistoryView.tsx
@@ -60,6 +60,8 @@ const SearchHistoryView = (): JSX.Element => {
     fetchSearchHistory,
     {
       suspense: true,
+      refetchOnMount: true, // 렌더 시 업데이트
+      staleTime: 2 * 1000, // 2초
     }
   );
 

--- a/client/src/hooks/usePostInfiniteScroll.ts
+++ b/client/src/hooks/usePostInfiniteScroll.ts
@@ -71,10 +71,6 @@ const usePostInfiniteScroll = (): PostInfiniteScrollResults => {
         { queryKey: [QUERY_KEYS.POSTS], exact: true },
         { cancelRefetch: true }
       );
-      await queryClient.refetchQueries({
-        queryKey: [QUERY_KEYS.HISTORY],
-        type: "active",
-      });
     })();
   }, [filter, searchType]);
 

--- a/client/src/mocks/handlers/searchHandler.ts
+++ b/client/src/mocks/handlers/searchHandler.ts
@@ -8,7 +8,7 @@ const baseUrl = API_SERVER_URL;
 
 export const searchHandler = [
   rest.get(`${baseUrl}/search/histories`, (req, res, ctx) => {
-    return res(ctx.status(200), ctx.delay(1000), ctx.json(history));
+    return res(ctx.status(200), ctx.delay(500), ctx.json(history));
   }),
   rest.delete(`${baseUrl}/search/histories/:id`, (req, res, ctx) => {
     setHistory(


### PR DESCRIPTION
# 요약

- 검색 요청 시 검색 창이 닫히도록 구현
- 검색 창이 열릴 때 history 요청하도록 구현
- 최적화를 진행하려다가 너무 오래 걸릴 것 같아서 일단 기능부터 붙였습니다.

# 연관 이슈

- fix #347 
<!--이슈 번호를 적어주세요(예시: fix #123). -->

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
    - 좋은 예시) feat [FE] : 깃허브 로그인 버튼 컴포넌트 구현 (#13)
    - 나쁜 예시) feat: 로그인 구현