### PR TITLE
feat(FE): 유저 닉네임, 프로필 사진 클릭 시 해당 유저의 게시글만 보이는 기능 추가 (#352)

### DIFF
--- a/client/src/components/main/PostScroll/Post/PostTitle/AuthorProfile/AuthorProfile.scss
+++ b/client/src/components/main/PostScroll/Post/PostTitle/AuthorProfile/AuthorProfile.scss
@@ -12,33 +12,19 @@
     height: 80%;
     border-radius: 50%;
     object-fit: contain;
+
+    &:hover {
+      cursor: pointer;
+    }
   }
 
   &__username {
     font-size: $font-medium;
-  }
 
-  &__follow-button {
-    @include green-button;
-    width: fit-content;
-    height: 1.4rem;
-
-    font-size: $font-form;
-
-    &--on {
-      @include weview-button;
-      width: fit-content;
-      height: 1.5rem;
-
-      font-size: $font-form;
-
-      color: $line-color !important;
-      border: 1px solid $line-color;
-
-      &:hover {
-        color: $weview-off-white !important;
-        background-color: $line-color;
-      }
+    &:hover {
+      text-decoration: underline;
+      cursor: pointer;
+      background-color: $light-gray;
     }
   }
 }

--- a/client/src/components/main/PostScroll/Post/PostTitle/AuthorProfile/AuthorProfile.tsx
+++ b/client/src/components/main/PostScroll/Post/PostTitle/AuthorProfile/AuthorProfile.tsx
@@ -1,19 +1,27 @@
 import React, { useContext } from "react";
 
 import { PostContext } from "@/components/main/PostScroll/Post/Post";
+import useSearchStore from "@/store/useSearchStore";
 
 import "./AuthorProfile.scss";
 
 const AuthorProfile = (): JSX.Element => {
   const { author } = useContext(PostContext);
+  const searchAuthorFilter = useSearchStore(
+    (state) => state.searchAuthorFilter
+  );
 
   return (
     <div className="post__title__author-profile">
       <img
         className="post__title__author-profile__image"
         src={author.profileUrl}
+        onClick={() => searchAuthorFilter({ userId: author.id })}
       />
-      <div className="post__title__author-profile__username">
+      <div
+        className="post__title__author-profile__username"
+        onClick={() => searchAuthorFilter({ userId: author.id })}
+      >
         {author.nickname}
       </div>
     </div>

--- a/client/src/mocks/datasource/mockDataSource.ts
+++ b/client/src/mocks/datasource/mockDataSource.ts
@@ -16,7 +16,7 @@ export const mockUser: MyInfo = {
 export const posts: PostInfo[] = Array.from(Array(1024).keys()).map((id) => ({
   id: `${id}`,
   title: `제목_${id}`,
-  content: id % 2 ? LARGE_CONTENT : SMALL_CONTENT,
+  content: id % 2 === 0 ? LARGE_CONTENT : SMALL_CONTENT,
   images: [
     {
       src: "http://placeimg.com/640/640/animals",
@@ -28,7 +28,7 @@ export const posts: PostInfo[] = Array.from(Array(1024).keys()).map((id) => ({
     },
   ],
   author: {
-    id: `${id}`,
+    id: `${id % 100}`,
     nickname: `sampleUser_${id + 10000}`,
     profileUrl: "http://placeimg.com/640/640/animals",
     email: `name_${id + 10000}@gmail.com`,


### PR DESCRIPTION
# 요약

https://user-images.githubusercontent.com/63703962/206141796-110e461c-2d93-4579-a678-2350bfa76066.mov

- 프로필 사진, 유저 닉네임 클릭 이벤트 등록
- 해당 유저가 작성한 모든 게시글을 무한 스크롤로 로딩

# 연관 이슈

- related #352 
<!--이슈 번호를 적어주세요(예시: fix #123). -->

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
    - 좋은 예시) feat [FE] : 깃허브 로그인 버튼 컴포넌트 구현 (#13)
    - 나쁜 예시) feat: 로그인 구현