### PR TITLE
글 상세 조회, 북마크 글 목록 API에서 좋아요/북마크 여부 표시

### DIFF
--- a/server/src/domain/bookmark/bookmark.module.ts
+++ b/server/src/domain/bookmark/bookmark.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+import { LikesRepository } from '../likes/likes.repository';
 import { PostRepository } from '../post/post.repository';
 import { UserRepository } from '../user/user.repository';
 import { BookmarkController } from './bookmark.controller';
@@ -12,6 +13,7 @@ import { BookmarkService } from './bookmark.service';
     BookmarkRepository,
     UserRepository,
     PostRepository,
+    LikesRepository,
   ],
   exports: [BookmarkService, BookmarkRepository],
 })

--- a/server/src/domain/likes/likes.service.ts
+++ b/server/src/domain/likes/likes.service.ts
@@ -45,6 +45,15 @@ export class LikesService {
     return postsYouLiked.map((likesInfo) => likesInfo.postId);
   }
 
+  async getIsLiked(postId: number, userId: number) {
+    const likes = await this.likesRepository.findOneBy({
+      postId,
+      userId,
+    });
+
+    return !!likes;
+  }
+
   async countLikesCntByPostId(postId: number) {
     return this.likesRepository.count({
       where: {


### PR DESCRIPTION
# 요약
- 글 상세 조회 API에서 좋아요, 북마크 여부를 표시하도록 했습니다.
- 북마크 글 목록 API에서 좋아요 여부를 표시하도록 했습니다.

# 연관 이슈
- related #361 

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
    - 좋은 예시) feat [FE] : 깃허브 로그인 버튼 컴포넌트 구현 (#13)
    - 나쁜 예시) feat: 로그인 구현