### PR TITLE
fix(FE): 북마크 낙관적 업데이트가 페이지 전환 시 되지 않던 오류 수정 (#346)

### DIFF
--- a/client/src/apis/post.ts
+++ b/client/src/apis/post.ts
@@ -13,7 +13,11 @@ import useSearchStore from "@/store/useSearchStore";
 import useWritingStore from "@/store/useWritingStore";
 import { getLineCount } from "@/utils/code";
 import useCodeEditorStore from "@/store/useCodeEditorStore";
-import { AuthorSearchFilter, SearchFilter } from "@/types/search";
+import {
+  AuthorSearchFilter,
+  SearchFilter,
+  SingleSearchFilter,
+} from "@/types/search";
 
 export const fetchPost = async (pageParam: string): Promise<PostPages> => {
   const filter = useSearchStore.getState().filter as SearchFilter;
@@ -35,6 +39,16 @@ export const fetchBookmarkPost = async (
   pageParam: string
 ): Promise<PostPages> => {
   const { data } = await axiosInstance.get(`/bookmarks?lastId=${pageParam}`);
+  return data;
+};
+
+export const fetchSinglePost = async (
+  pageParam: string
+): Promise<PostPages> => {
+  const filter = useSearchStore.getState().filter as SingleSearchFilter;
+  const { data } = await axiosInstance.get(
+    `/posts/${filter.postId}?lastId=${pageParam}`
+  );
   return data;
 };
 
@@ -89,12 +103,5 @@ export const toggleLikeAPI = async ({
   const { data } = isLiked
     ? await axiosInstance.delete(`/posts/${postId}/likes`)
     : await axiosInstance.post(`/posts/${postId}/likes`);
-  return data;
-};
-
-export const getPostItem = async (
-  postId: string
-): Promise<{ post: PostInfo }> => {
-  const { data } = await axiosInstance.get(`/posts/${postId}`);
   return data;
 };

--- a/client/src/components/main/PostScroll/Post/PostFooter/LeftBlockItems/BookmarkButton.tsx
+++ b/client/src/components/main/PostScroll/Post/PostFooter/LeftBlockItems/BookmarkButton.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from "react";
+import React, { useContext, useEffect } from "react";
 import BookmarkBorderIcon from "@mui/icons-material/BookmarkBorder";
 import BookmarkAddedIcon from "@mui/icons-material/BookmarkAdded";
 

--- a/client/src/components/main/PostScroll/Post/PostFooter/RightBlockItems/MoreButton.tsx
+++ b/client/src/components/main/PostScroll/Post/PostFooter/RightBlockItems/MoreButton.tsx
@@ -1,5 +1,6 @@
 import React, { useContext } from "react";
 import MoreHorizIcon from "@mui/icons-material/MoreHoriz";
+import { useNavigate } from "react-router-dom";
 
 import SvgIconButton from "@/components/commons/SvgIconButton/SvgIconButton";
 import useModal from "@/hooks/useModal";
@@ -9,8 +10,11 @@ import { MODAL_KEY } from "@/types/modal";
 import "./RightBlockItems.scss";
 
 const MoreButton = (): JSX.Element => {
+  const navigate = useNavigate();
   const { id, author } = useContext(PostContext);
   const { handleModalOpen } = useModal();
+
+  const handleSinglePost = (): void => navigate(`/post/${id}`);
 
   return (
     <>
@@ -21,6 +25,7 @@ const MoreButton = (): JSX.Element => {
           handleModalOpen(MODAL_KEY.POST_MORE, {
             postId: id,
             authorId: author.id,
+            navigate: handleSinglePost,
           })
         }
         className="post__footer__right-block--btn"

--- a/client/src/components/main/PostScroll/Post/PostFooter/RightBlockItems/PostMoreModal/PostMoreModal.tsx
+++ b/client/src/components/main/PostScroll/Post/PostFooter/RightBlockItems/PostMoreModal/PostMoreModal.tsx
@@ -52,7 +52,7 @@ const PostMoreModal = ({
           <PostMoreModalMenu text={"삭제"} onClick={handleDeletePost} />
         )}
         <PostMoreModalMenu
-          text={"게시글 보기"}
+          text={"포스트 보기"}
           onClick={handleDisplaySinglePost}
         />
         <PostMoreModalMenu text={"취소"} onClick={handleModalClose} />

--- a/client/src/components/main/PostScroll/Post/PostFooter/RightBlockItems/PostMoreModal/PostMoreModal.tsx
+++ b/client/src/components/main/PostScroll/Post/PostFooter/RightBlockItems/PostMoreModal/PostMoreModal.tsx
@@ -17,6 +17,7 @@ interface PostMoreModalProps extends ModalProps {}
 const PostMoreModal = ({
   postId,
   authorId,
+  navigate,
 }: PostMoreModalProps): JSX.Element => {
   const { isLoggedIn, myInfo } = useAuth();
   const { handleModalClose } = useModal();
@@ -35,12 +36,22 @@ const PostMoreModal = ({
     })();
   };
 
+  const handleDisplaySinglePost = (): void => {
+    try {
+      navigate?.();
+      handleModalClose();
+    } catch (e: any) {
+      alert(e.message);
+    }
+  };
+
   return (
     <Modal onClose={handleModalClose} title={"메뉴를 선택해주세요."}>
       <div className="post-more">
         {isDeletable && (
           <PostMoreModalMenu text={"삭제"} onClick={handleDeletePost} />
         )}
+        <PostMoreModalMenu text={"글 보기"} onClick={handleDisplaySinglePost} />
         <PostMoreModalMenu text={"취소"} onClick={handleModalClose} />
       </div>
     </Modal>

--- a/client/src/components/main/PostScroll/Post/PostFooter/RightBlockItems/PostMoreModal/PostMoreModal.tsx
+++ b/client/src/components/main/PostScroll/Post/PostFooter/RightBlockItems/PostMoreModal/PostMoreModal.tsx
@@ -51,7 +51,10 @@ const PostMoreModal = ({
         {isDeletable && (
           <PostMoreModalMenu text={"삭제"} onClick={handleDeletePost} />
         )}
-        <PostMoreModalMenu text={"글 보기"} onClick={handleDisplaySinglePost} />
+        <PostMoreModalMenu
+          text={"게시글 보기"}
+          onClick={handleDisplaySinglePost}
+        />
         <PostMoreModalMenu text={"취소"} onClick={handleModalClose} />
       </div>
     </Modal>

--- a/client/src/hooks/useBookmark.ts
+++ b/client/src/hooks/useBookmark.ts
@@ -1,10 +1,12 @@
-import { useMutation } from "@tanstack/react-query";
-import { MouseEventHandler, useState } from "react";
+import { InfiniteData, useMutation } from "@tanstack/react-query";
+import { MouseEventHandler } from "react";
 
 import useAuth from "@/hooks/useAuth";
 import { queryClient } from "@/react-query/queryClient";
 import { QUERY_KEYS } from "@/react-query/queryKeys";
 import { addBookmarkPost, removeBookmarkPost } from "@/apis/bookmark";
+import { PostPages } from "@/types/post";
+import useSearchStore from "@/store/useSearchStore";
 
 interface UseBookmark {
   postId: string;
@@ -20,9 +22,11 @@ const useBookmark = ({
   postId,
   isBookmarked,
 }: UseBookmark): UseBookmarkResult => {
-  const [isBookmarkedState, setIsBookmarkedState] = useState(
-    isBookmarked !== undefined && isBookmarked
-  );
+  const queryFilters = useSearchStore((state) => [
+    state.searchType,
+    state.filter,
+  ]);
+  const isBookmarkedState = isBookmarked !== undefined && isBookmarked;
   const { isLoggedIn } = useAuth();
 
   // 북마크 토글을 시도하고, 실패하면 원래 상태로 롤백하는 로직
@@ -33,18 +37,50 @@ const useBookmark = ({
     {
       onMutate: async () => {
         await queryClient.cancelQueries([QUERY_KEYS.POSTS]);
-        const previousPosts = queryClient.getQueriesData([
+
+        // Query Key에 따라서 보고 있는 스크롤이 다르기 때문에, 현재 보이는 화면의 스크롤바 데이터를 가져옴
+        const cache = queryClient.getQueryData<InfiniteData<PostPages>>([
           QUERY_KEYS.POSTS,
-        ])[0][1];
-        setIsBookmarkedState(!isBookmarkedState);
-        return { previousPosts };
+          ...queryFilters,
+        ]);
+
+        // 현재 보고 있는 화면의 스크롤바 데이터만 낙관적으로 업데이트
+        queryClient.setQueryData<InfiniteData<PostPages>>(
+          [QUERY_KEYS.POSTS, ...queryFilters],
+          (oldPages) => {
+            if (oldPages === undefined) {
+              return { pages: [], pageParams: [] };
+            }
+            return {
+              pages: oldPages.pages.map((page) => ({
+                ...page,
+                posts: page.posts.map((postInfo) =>
+                  // 이전 데이터에서 postId 와 일치하는 부분만 상태를 바꿔서 낙관적 업데이트
+                  postInfo.id === postId
+                    ? {
+                        ...postInfo,
+                        isBookmarked: !isBookmarkedState,
+                      }
+                    : postInfo
+                ),
+              })),
+              pageParams: oldPages.pageParams,
+            };
+          }
+        );
+
+        return { cache };
       },
       onError: (error, value, context) => {
-        console.log(error);
-        queryClient.setQueryData([QUERY_KEYS.POSTS], context?.previousPosts);
-        setIsBookmarkedState(isBookmarkedState);
+        // mutation 실패 시 변경 전 데이터로 되돌린다.
+        console.log("북마크 변경 실패", error);
+        queryClient.setQueryData(
+          [QUERY_KEYS.POSTS, ...queryFilters],
+          context?.cache
+        );
       },
       onSuccess: async () => {
+        // mutation 성공 시 서버 상태가 변경되었으므로 모든 포스트 스크롤에 대해 최신화를 진행
         await queryClient.invalidateQueries([QUERY_KEYS.POSTS]);
       },
     }

--- a/client/src/hooks/usePostInfiniteScroll.ts
+++ b/client/src/hooks/usePostInfiniteScroll.ts
@@ -11,7 +11,12 @@ import { PostPages } from "@/types/post";
 import useSearchStore, { SEARCH_FILTER } from "@/store/useSearchStore";
 import { queryClient } from "@/react-query/queryClient";
 import { QUERY_KEYS } from "@/react-query/queryKeys";
-import { fetchBookmarkPost, fetchPost, fetchUserPost } from "@/apis/post";
+import {
+  fetchBookmarkPost,
+  fetchPost,
+  fetchSinglePost,
+  fetchUserPost,
+} from "@/apis/post";
 
 const getQueryFn = async (
   pageParam: string,
@@ -23,6 +28,10 @@ const getQueryFn = async (
   }
   if (searchType === SEARCH_FILTER.BOOKMARK) {
     const postPages = await fetchBookmarkPost(pageParam);
+    return postPages;
+  }
+  if (searchType === SEARCH_FILTER.SINGLE) {
+    const postPages = await fetchSinglePost(pageParam);
     return postPages;
   }
 

--- a/client/src/mocks/handlers/postHandler.ts
+++ b/client/src/mocks/handlers/postHandler.ts
@@ -97,8 +97,12 @@ export const postHandler = [
     const userId = String(req.params.userId);
     const lastId = Number(req.url.searchParams.get("lastId")) + 1;
 
-    const filteredData = posts.filter((post) => post.author.id === userId);
-
+    const filteredData = posts
+      .filter((post) => post.author.id === userId)
+      .map((post) => ({
+        ...post,
+        isBookmarked: bookmarks.includes(Number(post.id)),
+      }));
     const isLast = filteredData.length <= lastId + SIZE;
 
     return res(

--- a/client/src/mocks/handlers/postHandler.ts
+++ b/client/src/mocks/handlers/postHandler.ts
@@ -116,7 +116,18 @@ export const postHandler = [
     );
   }),
   rest.get(`${baseUrl}/posts/:postId`, (req, res, ctx) => {
-    const postId = req.params.postId;
-    return res(ctx.status(200), ctx.json({ post: posts[Number(postId)] }));
+    const postId = String(req.params.postId);
+
+    const filteredData = posts
+      .filter((post) => post.id === postId)
+      .map((post) => ({
+        ...post,
+        isBookmarked: bookmarks.includes(Number(post.id)),
+      }));
+
+    return res(
+      ctx.status(200),
+      ctx.json({ posts: filteredData.slice(0, 1), lastId: -1, isLast: true })
+    );
   }),
 ];

--- a/client/src/pages/Post/Post.tsx
+++ b/client/src/pages/Post/Post.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useParams } from "react-router-dom";
 
@@ -10,6 +10,7 @@ import TagRanking from "@/components/main/TagRanking/TagRanking";
 import { PostInfo } from "@/types/post";
 import LoadingSpinner from "@/components/commons/LoadingSpinner/LoadingSpinner";
 import useWritingModalStore from "@/store/useWritingModalStore";
+import useSearchStore, { SEARCH_FILTER } from "@/store/useSearchStore";
 
 import "./Post.scss";
 
@@ -17,11 +18,17 @@ const Post = (): JSX.Element => {
   const [isWritingModalOpened] = useWritingModalStore((state) => [
     state.isWritingModalOpened,
   ]);
+  const searchSingleFilter = useSearchStore(
+    (state) => state.searchSingleFilter
+  );
   const { postId } = useParams();
   const { isLoading, data } = useQuery(
-    [QUERY_KEYS.POSTS],
+    [QUERY_KEYS.POSTS, SEARCH_FILTER.SINGLE, { postId }],
     async () => await getPostItem(postId as string)
   );
+  useEffect(() => {
+    searchSingleFilter({ postId: postId as string });
+  }, []);
 
   return (
     <div className={isWritingModalOpened ? "hidden-main" : "main"}>

--- a/client/src/pages/Post/Post.tsx
+++ b/client/src/pages/Post/Post.tsx
@@ -1,16 +1,11 @@
 import React, { useEffect } from "react";
-import { useQuery } from "@tanstack/react-query";
 import { useParams } from "react-router-dom";
 
 import MainNav from "@/components/main/MainNav/MainNav";
-import { QUERY_KEYS } from "@/react-query/queryKeys";
-import { getPostItem } from "@/apis/post";
-import PostItem from "@/components/main/PostScroll/Post/Post";
 import TagRanking from "@/components/main/TagRanking/TagRanking";
-import { PostInfo } from "@/types/post";
-import LoadingSpinner from "@/components/commons/LoadingSpinner/LoadingSpinner";
 import useWritingModalStore from "@/store/useWritingModalStore";
-import useSearchStore, { SEARCH_FILTER } from "@/store/useSearchStore";
+import useSearchStore from "@/store/useSearchStore";
+import PostScroll from "@/components/main/PostScroll/PostScroll";
 
 import "./Post.scss";
 
@@ -22,10 +17,6 @@ const Post = (): JSX.Element => {
     (state) => state.searchSingleFilter
   );
   const { postId } = useParams();
-  const { isLoading, data } = useQuery(
-    [QUERY_KEYS.POSTS, SEARCH_FILTER.SINGLE, { postId }],
-    async () => await getPostItem(postId as string)
-  );
   useEffect(() => {
     searchSingleFilter({ postId: postId as string });
   }, []);
@@ -34,13 +25,7 @@ const Post = (): JSX.Element => {
     <div className={isWritingModalOpened ? "hidden-main" : "main"}>
       <MainNav />
       <div className="main__content">
-        <div className="post-item-box">
-          {isLoading ? (
-            <LoadingSpinner />
-          ) : (
-            <PostItem postInfo={data?.post as PostInfo} />
-          )}
-        </div>
+        <PostScroll />
         <TagRanking />
       </div>
     </div>

--- a/client/src/store/useSearchStore.ts
+++ b/client/src/store/useSearchStore.ts
@@ -1,12 +1,18 @@
 import create from "zustand";
 import { devtools } from "zustand/middleware";
 
-import { AuthorSearchFilter, SearchFilter, SearchType } from "@/types/search";
+import {
+  AuthorSearchFilter,
+  SearchFilter,
+  SearchType,
+  SingleSearchFilter,
+} from "@/types/search";
 
 export enum SEARCH_FILTER {
   DEFAULT,
   AUTHOR,
   BOOKMARK,
+  SINGLE,
 }
 
 interface SearchStates {
@@ -17,6 +23,7 @@ interface SearchStates {
 interface SearchActions {
   searchDefaultFilter: (query: SearchFilter) => void;
   searchAuthorFilter: (query: AuthorSearchFilter) => void;
+  searchSingleFilter: (query: SingleSearchFilter) => void;
   searchBookmarkFilter: () => void;
   reset: () => void;
 }
@@ -49,6 +56,13 @@ const useSearchStore = create<SearchStore>()(
       set({
         ...initialSearchStates,
         searchType: SEARCH_FILTER.BOOKMARK,
+      });
+    },
+    searchSingleFilter: (singleSearchQuery: SingleSearchFilter) => {
+      set({
+        ...initialSearchStates,
+        filter: singleSearchQuery,
+        searchType: SEARCH_FILTER.SINGLE,
       });
     },
     reset: () => set(initialSearchStates),

--- a/client/src/store/useSearchStore.ts
+++ b/client/src/store/useSearchStore.ts
@@ -31,7 +31,7 @@ interface SearchActions {
 interface SearchStore extends SearchStates, SearchActions {}
 
 const initialSearchStates: SearchStates = {
-  filter: {},
+  filter: { lastId: "-1" },
   searchType: SEARCH_FILTER.DEFAULT,
 };
 

--- a/client/src/types/modal.ts
+++ b/client/src/types/modal.ts
@@ -5,6 +5,7 @@ export enum MODAL_KEY {
 export interface ModalProps {
   postId?: string;
   authorId?: string;
+  navigate?: () => void;
 }
 
 export interface ModalContext {

--- a/client/src/types/search.ts
+++ b/client/src/types/search.ts
@@ -5,6 +5,10 @@ export interface Label {
   value: string;
 }
 
+export interface SingleSearchFilter {
+  postId: string;
+}
+
 export interface SearchFilter extends InfiniteScrollRequest {
   details?: string[];
   tags?: string[];
@@ -24,7 +28,8 @@ export interface AuthorSearchFilter extends InfiniteScrollRequest {
 export type SearchType =
   | SearchFilter
   | BookmarkSearchFilter
-  | AuthorSearchFilter;
+  | AuthorSearchFilter
+  | SingleSearchFilter;
 
 export interface SearchHistory {
   tags: string[] | null;

--- a/client/src/types/search.ts
+++ b/client/src/types/search.ts
@@ -5,7 +5,7 @@ export interface Label {
   value: string;
 }
 
-export interface SingleSearchFilter {
+export interface SingleSearchFilter extends InfiniteScrollRequest {
   postId: string;
 }
 


### PR DESCRIPTION
# 요약

- 기존에 북마크 페이지에서 북마크를 해제하고 다시 검색 창으로 이동하는 등 페이지 전환 시 북마크가 갱신되지 않던 오류 발생
- 현재 보고 있는 스크롤바의 쿼리 키 : [QUERY_KEYS.POSTS, searchType, filter] 로 구성되어 있음.

![image](https://user-images.githubusercontent.com/63703962/206472953-36f05f2e-36fe-4229-afa9-e3edef5580aa.png)


- 북마크 갱신 mutation에 해당 쿼리 키를 명시해서 현재 보고 있는 화면에 대한 낙관적 업데이트 적용
- 오류가 발생했을 시 서버 상태가 변경되지 않았으므로 이전 상태로 롤백
- 갱신 성공 시 서버 상태가 변경되었으므로 다른 모든 스크롤바에 대해 업데이트 진행
- 로컬 mock환경에서 작동 확인

# 연관 이슈

- fix #346 

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
    - 좋은 예시) feat [FE] : 깃허브 로그인 버튼 컴포넌트 구현 (#13)
    - 나쁜 예시) feat: 로그인 구현