### PR TITLE
태그 내비게이트 및 사용성 개선 

### DIFF
--- a/client/src/components/main/TagRanking/TagRankingItem/TagRankingItem.tsx
+++ b/client/src/components/main/TagRanking/TagRankingItem/TagRankingItem.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from "react";
+import { useNavigate } from "react-router-dom";
 import HorizontalRuleIcon from "@mui/icons-material/HorizontalRule";
 import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
 import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
@@ -19,8 +20,10 @@ const TagRankingItem = ({ tagInfo }: PopularTagBoxProps): JSX.Element => {
   const [searchDefaultFilter] = useSearchStore((state) => [
     state.searchDefaultFilter,
   ]);
+  const navigate = useNavigate();
   const handleItemClick = useCallback((): void => {
     searchDefaultFilter({ tags: [tagInfo.name], lastId: "-1" });
+    navigate("/");
   }, []);
 
   return (

--- a/client/src/styles/_mixin.scss
+++ b/client/src/styles/_mixin.scss
@@ -22,7 +22,7 @@
   width: $line-width;
   height: 100%;
   overflow-x: hidden;
-  overflow-y: auto;
+  overflow-y: hidden;
   font-family: D2Coding, "D2 coding", monospace;
   color: $weview-white;
   text-align: end;

--- a/client/src/utils/code.ts
+++ b/client/src/utils/code.ts
@@ -21,8 +21,10 @@ export const chunkHTML = (htmlData: string[]): string[][] => {
 
 export const wrapHTML = (chunkedHTML: string[][]): string =>
   chunkedHTML
-    .map(
-      (arr, idx) =>
-        `<div class=chunked-${idx + 1}><div>${arr.join("\n")}</div></div>`
-    )
+    .map((arr, idx) => {
+      return `<div class=chunked-${idx + 1}><div>${arr
+        // 배열의 마지막 원소가 빈 문자열일 때 join하면 개행이 사라지므로 이를 확인하여 추가
+        .map((item, idx2) => (item === "" && idx2 === 14 ? "<br/>" : item))
+        .join("\n")}</div></div>`;
+    })
     .join("");


### PR DESCRIPTION
# 요약
<!--해당 PR에 대한 설명 혹은 이미지등을 넣어주세요. -->
태그 내비게이트 및 사용성 개선 
# 연관 이슈
에디터의 관련된 버그와 개별 포스트 창에서 인기태그 검색 클릭 시 내비게이트 되게끔 설정해놓았습니다.
# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
    - 좋은 예시) feat [FE] : 깃허브 로그인 버튼 컴포넌트 구현 (#13)
    - 나쁜 예시) feat: 로그인 구현