### PR TITLE
fix(BE): 도커 컨테이너에 timezone 패키지 설치 (#363)

### DIFF
--- a/scheduler-server/Dockerfile
+++ b/scheduler-server/Dockerfile
@@ -6,6 +6,7 @@ COPY . .
 RUN npm run build
 
 FROM node:16-alpine AS production
+RUN apk add tzdata
 WORKDIR /usr/src/app
 COPY package*.json ./
 RUN npm install --only=production --ignore-scripts

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -6,6 +6,7 @@ COPY . .
 RUN npm run build
 
 FROM node:16-alpine AS production
+RUN apk add tzdata
 WORKDIR /usr/src/app
 COPY package*.json ./
 RUN npm install --only=production --ignore-scripts


### PR DESCRIPTION
# 요약
- 도커 컴포즈에 다음처럼 timezone 설정을 추가했는데 적용이 되지 않았습니다.
![image](https://user-images.githubusercontent.com/55542546/206969334-03b5b0b3-f04b-48bc-a56d-796b611900d8.png)
- 알아보니 경량 버전인 alpine에는 timezone 패키지가 없어서 설정이 적용되지 않기에, 도커 파일에 timezone 패키지를 설치하는 코드를 추가했습니다.

# 연관 이슈
- related #363 

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
    - 좋은 예시) feat [FE] : 깃허브 로그인 버튼 컴포넌트 구현 (#13)
    - 나쁜 예시) feat: 로그인 구현