### PR TITLE
엘라스틱서치를 적용했습니다.

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -9,10 +9,12 @@
       "version": "0.1.0",
       "license": "UNLICENSED",
       "dependencies": {
+        "@elastic/elasticsearch": "^8.5.0",
         "@nestjs/axios": "^1.0.0",
         "@nestjs/common": "^9.0.0",
         "@nestjs/config": "^2.2.0",
         "@nestjs/core": "^9.0.0",
+        "@nestjs/elasticsearch": "^9.0.0",
         "@nestjs/jwt": "^9.0.0",
         "@nestjs/passport": "^9.0.0",
         "@nestjs/platform-express": "^9.0.0",
@@ -827,6 +829,39 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@elastic/elasticsearch": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-8.5.0.tgz",
+      "integrity": "sha512-iOgr/3zQi84WmPhAplnK2W13R89VXD2oc6WhlQmH3bARQwmI+De23ZJKBEn7bvuG/AHMAqasPXX7uJIiJa2MqQ==",
+      "dependencies": {
+        "@elastic/transport": "^8.2.0",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@elastic/transport": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@elastic/transport/-/transport-8.2.0.tgz",
+      "integrity": "sha512-H/HmefMNQfLiBSVTmNExu2lYs5EzwipUnQB53WLr17RCTDaQX0oOLHcWpDsbKQSRhDAMPPzp5YZsZMJxuxPh7A==",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "hpagent": "^1.0.0",
+        "ms": "^2.1.3",
+        "secure-json-parse": "^2.4.0",
+        "tslib": "^2.4.0",
+        "undici": "^5.1.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@elastic/transport/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
     "node_modules/@eslint/eslintrc": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
@@ -1614,6 +1649,16 @@
         "@nestjs/websockets": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@nestjs/elasticsearch": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/elasticsearch/-/elasticsearch-9.0.0.tgz",
+      "integrity": "sha512-+NhXg0od/luNuObrCoouO8IGJ5d8esd2LbqOyX4wqM3PtzoVgQC5uDoxHu0ZyWkp/Coj7OiT0osYN9rgctEPbg==",
+      "peerDependencies": {
+        "@elastic/elasticsearch": "^7.4.0 || ^8.0.0",
+        "@nestjs/common": "^8.0.0 || ^9.0.0",
+        "rxjs": "^7.2.0"
       }
     },
     "node_modules/@nestjs/jwt": {
@@ -5362,6 +5407,14 @@
         "node": "*"
       }
     },
+    "node_modules/hpagent": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+      "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -8903,6 +8956,11 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
     },
+    "node_modules/secure-json-parse": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.6.0.tgz",
+      "integrity": "sha512-B9osKohb6L+EZ6Kve3wHKfsAClzOC/iISA2vSuCe5Jx5NAKiwitfxx8ZKYapHXr0sYRj7UZInT7pLb3rp2Yx6A=="
+    },
     "node_modules/semver": {
       "version": "7.3.8",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -10142,6 +10200,17 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/undici": {
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.13.0.tgz",
+      "integrity": "sha512-UDZKtwb2k7KRsK4SdXWG7ErXiL7yTGgLWvk2AXO1JMjgjh404nFo6tWSCM2xMpJwMPx3J8i/vfqEh1zOqvj82Q==",
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12.18"
+      }
+    },
     "node_modules/unique-filename": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-1.1.1.tgz",
@@ -11211,6 +11280,35 @@
         }
       }
     },
+    "@elastic/elasticsearch": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-8.5.0.tgz",
+      "integrity": "sha512-iOgr/3zQi84WmPhAplnK2W13R89VXD2oc6WhlQmH3bARQwmI+De23ZJKBEn7bvuG/AHMAqasPXX7uJIiJa2MqQ==",
+      "requires": {
+        "@elastic/transport": "^8.2.0",
+        "tslib": "^2.4.0"
+      }
+    },
+    "@elastic/transport": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@elastic/transport/-/transport-8.2.0.tgz",
+      "integrity": "sha512-H/HmefMNQfLiBSVTmNExu2lYs5EzwipUnQB53WLr17RCTDaQX0oOLHcWpDsbKQSRhDAMPPzp5YZsZMJxuxPh7A==",
+      "requires": {
+        "debug": "^4.3.4",
+        "hpagent": "^1.0.0",
+        "ms": "^2.1.3",
+        "secure-json-parse": "^2.4.0",
+        "tslib": "^2.4.0",
+        "undici": "^5.1.1"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+        }
+      }
+    },
     "@eslint/eslintrc": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.3.3.tgz",
@@ -11802,6 +11900,12 @@
         "tslib": "2.4.1",
         "uuid": "9.0.0"
       }
+    },
+    "@nestjs/elasticsearch": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/elasticsearch/-/elasticsearch-9.0.0.tgz",
+      "integrity": "sha512-+NhXg0od/luNuObrCoouO8IGJ5d8esd2LbqOyX4wqM3PtzoVgQC5uDoxHu0ZyWkp/Coj7OiT0osYN9rgctEPbg==",
+      "requires": {}
     },
     "@nestjs/jwt": {
       "version": "9.0.0",
@@ -14668,6 +14772,11 @@
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
       "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A=="
     },
+    "hpagent": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+      "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA=="
+    },
     "html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -17290,6 +17399,11 @@
         }
       }
     },
+    "secure-json-parse": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.6.0.tgz",
+      "integrity": "sha512-B9osKohb6L+EZ6Kve3wHKfsAClzOC/iISA2vSuCe5Jx5NAKiwitfxx8ZKYapHXr0sYRj7UZInT7pLb3rp2Yx6A=="
+    },
     "semver": {
       "version": "7.3.8",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
@@ -18118,6 +18232,14 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
       "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
       "devOptional": true
+    },
+    "undici": {
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.13.0.tgz",
+      "integrity": "sha512-UDZKtwb2k7KRsK4SdXWG7ErXiL7yTGgLWvk2AXO1JMjgjh404nFo6tWSCM2xMpJwMPx3J8i/vfqEh1zOqvj82Q==",
+      "requires": {
+        "busboy": "^1.6.0"
+      }
     },
     "unique-filename": {
       "version": "1.1.1",

--- a/server/package.json
+++ b/server/package.json
@@ -22,10 +22,12 @@
     "prepare": "chmod ug+x .husky/* && cd .. && husky install server/.husky"
   },
   "dependencies": {
+    "@elastic/elasticsearch": "^8.5.0",
     "@nestjs/axios": "^1.0.0",
     "@nestjs/common": "^9.0.0",
     "@nestjs/config": "^2.2.0",
     "@nestjs/core": "^9.0.0",
+    "@nestjs/elasticsearch": "^9.0.0",
     "@nestjs/jwt": "^9.0.0",
     "@nestjs/passport": "^9.0.0",
     "@nestjs/platform-express": "^9.0.0",

--- a/server/src/domain/image/image.entity.ts
+++ b/server/src/domain/image/image.entity.ts
@@ -10,6 +10,9 @@ export class Image extends BaseTimeEntity {
   @ManyToOne(() => Post, (post) => post.images)
   post: Post;
 
+  @Column()
+  postId: number;
+
   @Column({ length: 2000 })
   src!: string;
 }

--- a/server/src/domain/image/image.repository.ts
+++ b/server/src/domain/image/image.repository.ts
@@ -1,0 +1,10 @@
+import { DataSource, Repository } from 'typeorm';
+import { Injectable } from '@nestjs/common';
+import { Image } from './image.entity';
+
+@Injectable()
+export class ImageRepository extends Repository<Image> {
+  constructor(private dataSource: DataSource) {
+    super(Image, dataSource.createEntityManager());
+  }
+}

--- a/server/src/domain/likes/likes.service.ts
+++ b/server/src/domain/likes/likes.service.ts
@@ -29,13 +29,23 @@ export class LikesService {
     likes.user = user;
     likes.post = post;
     await this.likesRepository.save(likes);
+    this.postRepository.increaseLikeCount(post);
   }
 
   async cancelLikes(userId: number, postId: number) {
+    const [user, post] = await Promise.all([
+      this.userRepository.findOneBy({ id: userId }),
+      this.postRepository.findOneBy({ id: postId }),
+    ]);
+    if (post === null || user === null) {
+      return;
+    }
+
     await this.likesRepository.delete({
       userId: userId,
       postId: postId,
     });
+    this.postRepository.decreaseLikeCount(post);
   }
 
   async findPostIdsByUserId(userId: number) {

--- a/server/src/domain/post/dto/controller-response.dto.ts
+++ b/server/src/domain/post/dto/controller-response.dto.ts
@@ -1,44 +1,59 @@
-export class InquiryUsingFilterDto {
-  posts: PostDtoUsingInquiryUsingFilter[];
+import { SearchHit } from '@elastic/elasticsearch/lib/api/types';
+import { AuthorDto, EachImageResponseDto } from './service-response.dto';
+import { Image } from '../../image/image.entity';
+import { User } from '../../user/user.entity';
+
+export class SearchResponseDto {
+  posts: EachSearchResponseDto[];
   lastId: number;
   isLast: boolean;
+
+  constructor(
+    posts: SearchHit<PostSearchResult>[],
+    authors: User[],
+    imagesList: Image[][],
+    isLast: boolean,
+  ) {
+    this.posts = [];
+    for (let i = 0; i < posts.length; i++) {
+      this.posts.push(
+        new EachSearchResponseDto(posts[i], authors[i], imagesList[i]),
+      );
+    }
+
+    this.lastId = posts.length == 0 ? -1 : Number(posts.slice(-1)[0]._id);
+    this.isLast = isLast;
+  }
 }
 
-export class PostDtoUsingInquiryUsingFilter {
+export class EachSearchResponseDto {
   id: number;
   title: string;
   content: string;
   code: string;
   language: string;
-  images: ImageDtoUsingInquiryUsingFilter[];
-  updatedAt: string;
-  author: AuthorDtoUsingInquiryUsingFilter[];
+  images: EachImageResponseDto[];
+  updatedAt: Date;
+  author: AuthorDto;
   tags: string[];
-  reviews: ReviewDtoUsingInquiryUsingFilter[];
-}
+  isLiked: boolean;
+  isBookmarked: boolean;
+  likesCount: number;
+  lineCount: number;
 
-export class ImageDtoUsingInquiryUsingFilter {
-  src: string;
-  name: string;
-}
-
-export class AuthorDtoUsingInquiryUsingFilter {
-  id: number;
-  nickname: string;
-  profileUrl: string;
-  email: string;
-}
-
-export class ReviewDtoUsingInquiryUsingFilter {
-  id: number;
-  reviewers: ReviewerDtoUsingInquiryUsingFilter[];
-  content: string;
-  updatedAt: string;
-}
-
-export class ReviewerDtoUsingInquiryUsingFilter {
-  id: number;
-  nickname: string;
-  profileUrl: string;
-  email: string;
+  constructor(post: any, author, images) {
+    this.id = Number(post._id);
+    this.title = post._source.title;
+    this.content = post._source.content;
+    this.code = post._source.code;
+    this.language = post._source.language;
+    this.updatedAt = post._source.updatedat;
+    this.tags = JSON.parse(post._source.tags);
+    this.isLiked = false;
+    this.isBookmarked = false;
+    this.likesCount = post._source.likecount;
+    this.lineCount = post._source.linecount;
+    this.author = new AuthorDto(author);
+    this.images = images.map((image) => new EachImageResponseDto(image));
+  }
 }

--- a/server/src/domain/post/dto/controller-response.dto.ts
+++ b/server/src/domain/post/dto/controller-response.dto.ts
@@ -42,13 +42,23 @@ export class EachSearchResponseDto {
   lineCount: number;
 
   constructor(post: any, author, images) {
+    let tags;
+    try {
+      tags = JSON.parse(post._source.tags);
+    } catch (e) {
+      if (post._source.tags.length > 0) {
+        tags = [post._source.tags];
+      } else {
+        tags = [];
+      }
+    }
     this.id = Number(post._id);
     this.title = post._source.title;
     this.content = post._source.content;
     this.code = post._source.code;
     this.language = post._source.language;
     this.updatedAt = post._source.updatedat;
-    this.tags = JSON.parse(post._source.tags);
+    this.tags = tags;
     this.isLiked = false;
     this.isBookmarked = false;
     this.likesCount = post._source.likecount;

--- a/server/src/domain/post/dto/controller-response.dto.ts
+++ b/server/src/domain/post/dto/controller-response.dto.ts
@@ -2,8 +2,10 @@ import { SearchHit } from '@elastic/elasticsearch/lib/api/types';
 import { AuthorDto, EachImageResponseDto } from './service-response.dto';
 import { Image } from '../../image/image.entity';
 import { User } from '../../user/user.entity';
-import { SEND_POST_CNT } from '../post.controller';
 
+/**
+ * 정렬 기준을 한개만 사용하기 때문에(id desc) 0번째 인덱스를 사용하면 정렬된 값의 id를 꺼낼 수 있다
+ */
 const SORT_BY_ID = 0;
 
 export class SearchResponseDto {
@@ -29,11 +31,11 @@ export class SearchResponseDto {
   }
 
   private getLastId(posts: SearchHit<PostSearchResult>[]) {
-    return posts[SEND_POST_CNT - 1].sort[SORT_BY_ID];
+    return posts[posts.length - 1].sort[SORT_BY_ID];
   }
 }
 
-export class EachSearchResponseDto {
+class EachSearchResponseDto {
   id: number;
   title: string;
   content: string;

--- a/server/src/domain/post/dto/controller-response.dto.ts
+++ b/server/src/domain/post/dto/controller-response.dto.ts
@@ -2,6 +2,9 @@ import { SearchHit } from '@elastic/elasticsearch/lib/api/types';
 import { AuthorDto, EachImageResponseDto } from './service-response.dto';
 import { Image } from '../../image/image.entity';
 import { User } from '../../user/user.entity';
+import { SEND_POST_CNT } from '../post.controller';
+
+const SORT_BY_ID = 0;
 
 export class SearchResponseDto {
   posts: EachSearchResponseDto[];
@@ -21,8 +24,12 @@ export class SearchResponseDto {
       );
     }
 
-    this.lastId = posts.length == 0 ? -1 : Number(posts.slice(-1)[0]._id);
+    this.lastId = posts.length == 0 ? -1 : this.getLastId(posts);
     this.isLast = isLast;
+  }
+
+  private getLastId(posts: SearchHit<PostSearchResult>[]) {
+    return posts[SEND_POST_CNT - 1].sort[SORT_BY_ID];
   }
 }
 
@@ -52,7 +59,7 @@ export class EachSearchResponseDto {
         tags = [];
       }
     }
-    this.id = Number(post._id);
+    this.id = post._source.id;
     this.title = post._source.title;
     this.content = post._source.content;
     this.code = post._source.code;

--- a/server/src/domain/post/dto/service-request.dto.ts
+++ b/server/src/domain/post/dto/service-request.dto.ts
@@ -1,6 +1,7 @@
 import { IsInt, IsOptional, IsString, MaxLength, Min } from 'class-validator';
 
 export class LoadPostListRequestDto {
+  //TODO 이름 변경. SearchCondition..
   constructor(
     lastId: number,
     tags: string[],

--- a/server/src/domain/post/post-search.service.spec.ts
+++ b/server/src/domain/post/post-search.service.spec.ts
@@ -9,13 +9,14 @@ import { PostNotFoundException } from '../../exception/post-not-found.exception'
 import { PostInputInvalidException } from '../../exception/post-input-invalid.exception';
 import { SEND_POST_CNT } from './post.controller';
 import { SearchParamInvalidException } from '../../exception/search-param-invalid.exception';
+import { SearchResponseInvalidException } from '../../exception/search-response-invalid.exception';
+import { TagInvalidException } from '../../exception/tag-invalid.exception';
 
 const mockElasticSearchService = {
-  //TODO 위로 옮겨가도 테스트 할때마다 초기화가 될까?
   index: jest.fn(),
   search: jest.fn().mockResolvedValue({
     hits: {
-      hits: {},
+      hits: [],
     },
   }),
 };
@@ -27,8 +28,6 @@ describe('PostSearchService', () => {
   let service: PostSearchService;
   let esService: ElasticsearchService;
   let configService: ConfigService;
-
-  let post: Post;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -49,23 +48,6 @@ describe('PostSearchService', () => {
     service = module.get<PostSearchService>(PostSearchService);
     esService = module.get<ElasticsearchService>(ElasticsearchService);
     configService = module.get<ConfigService>(ConfigService);
-
-    const user = new User();
-    user.id = 10;
-    user.nickname = '사용자이름';
-
-    post = new Post();
-    post.id = 1;
-    post.title = '제목';
-    post.content = 'content';
-    post.code = 'System.out.println("zz")';
-    post.language = 'java';
-    post.createdAt = new Date();
-    post.updatedAt = new Date();
-    post.user = user;
-    post.lineCount = 1;
-    post.reviewCount = 0;
-    post.likeCount = 0;
   });
 
   it('should be defined', () => {
@@ -73,6 +55,47 @@ describe('PostSearchService', () => {
   });
 
   describe('저장', () => {
+    let post: Post;
+    let indexParameter;
+
+    beforeEach(async () => {
+      const user = new User();
+      user.id = 10;
+      user.nickname = '사용자이름';
+
+      post = new Post();
+      post.id = 1;
+      post.title = '제목';
+      post.content = 'content';
+      post.code = 'System.out.println("zz")';
+      post.language = 'java';
+      post.createdAt = new Date();
+      post.updatedAt = new Date();
+      post.user = user;
+      post.lineCount = 1;
+      post.reviewCount = 0;
+      post.likeCount = 0;
+
+      indexParameter = {
+        index: configService.get(''),
+        id: String(post.id),
+        body: {
+          id: post.id,
+          title: post.title,
+          content: post.content,
+          code: post.code,
+          language: post.language,
+          createdAt: post.createdAt,
+          updatedAt: post.updatedAt,
+          authorId: post.user.id,
+          authorNickname: post.user.nickname,
+          // tags: tagValue,
+          lineCount: post.lineCount,
+          reviewCount: post.reviewCount,
+          likeCount: post.likeCount,
+        },
+      };
+    });
     it('게시물이 들어오지 않으면 예외를 반환한다', () => {
       expect(() => {
         service.indexPost(null, ['greedy', 'sort']);
@@ -80,30 +103,56 @@ describe('PostSearchService', () => {
     });
 
     it('게시물이 1개 들어오면 정상적으로 동작한다', () => {
-      service.indexPost(post, ['greedy', 'sort']);
+      //given
+      const tags = ['greedy', 'sort'];
+
+      //when
+      service.indexPost(post, tags);
+      indexParameter.body.tags = tags.join(' ');
+
       expect(esService.index).toBeCalled();
-      // TODO 내부 값 테스트
+      expect(esService.index).toBeCalledWith(indexParameter);
     });
 
     it('태그가 0개 들어오면 정상 동작한다', () => {
       service.indexPost(post, []);
+      indexParameter.body.tags = ''; // 비어있는 값일 때 ''가 들어간다
+
       expect(esService.index).toBeCalled();
+      expect(esService.index).toBeCalledWith(indexParameter);
     });
 
     it('태그가 1개 들어오면 정상 동작한다', () => {
-      service.indexPost(post, ['one']);
+      //given
+      const tags = ['one'];
+      indexParameter.body.tags = tags[0];
+      //when
+      service.indexPost(post, tags);
+
       expect(esService.index).toBeCalled();
+      expect(esService.index).toBeCalledWith(indexParameter);
     });
 
     it('태그가 5개 들어오면 정상 동작한다', () => {
-      service.indexPost(post, ['one', 'two', 'three', 'four', 'five']);
+      const tags = ['one', 'two', 'three', 'four', 'five'];
+      indexParameter.body.tags = tags.join(' ');
+
+      service.indexPost(post, tags);
+
       expect(esService.index).toBeCalled();
+      expect(esService.index).toBeCalledWith(indexParameter);
     });
 
-    it('중복된 태그가 들어오면 예외를 반환한다', () => {
-      expect(() =>
-        service.indexPost(post, ['one', 'two', 'three', 'two', 'five']),
-      ).toThrow(PostInputInvalidException);
+    it('중복된 태그가 들어오면 중복을 제거하고 저장한다', () => {
+      //given
+      const tagsRemovedDuplicate = Array.from(
+        new Set(['one', 'two', 'three', 'two', 'five']),
+      );
+      indexParameter.body.tags = tagsRemovedDuplicate.join(' ');
+
+      //when
+      service.indexPost(post, ['one', 'two', 'three', 'two', 'five']);
+      expect(esService.index).toBeCalledWith(indexParameter);
     });
 
     it('태그가 6개 들어오면 예외를 반환한다', () => {
@@ -112,54 +161,35 @@ describe('PostSearchService', () => {
       ).toThrow(PostInputInvalidException);
     });
 
-    // TODO 태그를 객체로 분리하기
-    it('태그 중 10글자까지는 정상 동작한다', () => {
-      service.indexPost(post, ['가나다라마바사아자카']);
+    it('태그 하나의 글자수가 30개면 정상 동작한다', () => {
+      service.indexPost(post, [
+        '부스트캠프부스트캠프부스트캠프부스트캠프부스트캠프부스트캠프',
+      ]);
       expect(esService.index).toBeCalled();
     });
 
-    it('공백만 들어간 태그가 있으면 예외를 반환한다', () => {
+    it('태그 하나의 글자수가 31개면 예외를 반환한다', () => {
+      expect(() =>
+        service.indexPost(post, [
+          'one',
+          '부스트캠프부스트캠프부스트캠프부스트캠프부스트캠프부스트캠프1',
+          'three',
+          'four',
+          'five',
+        ]),
+      ).toThrow(TagInvalidException);
+    });
+
+    it('아무 값도 들어있지 않은 태그가 있으면 예외를 반환한다', () => {
       expect(() =>
         service.indexPost(post, ['one', '   ', 'three', 'four', 'five']),
-      ).toThrow(PostInputInvalidException);
+      ).toThrow(TagInvalidException);
     });
 
-    it('한글, 영대소문자, 숫자, 언더바 이외의 문자(#로 테스트)가 들어간 태그가 있으면 예외를 반환한다', () => {
+    it('공백이 포함된 태그가 있으면 예외를 반환한다', () => {
       expect(() =>
-        service.indexPost(post, ['one', 'two', '#three', 'four']),
-      ).toThrow(PostInputInvalidException);
-    });
-
-    it('한글, 영대소문자, 숫자, 언더바 이외의 문자가 들어간 태그(공백으로 테스트)가 있으면 예외를 반환한다', () => {
-      expect(() =>
-        service.indexPost(post, [' one', 'two', 'thre@e', 'four']),
-      ).toThrow(PostInputInvalidException);
-    });
-
-    it('각 태그에 한글, 영대소문자, 숫자, 언더바만 들어가면 정상 동작한다', () => {
-      expect(() =>
-        service.indexPost(post, ['한글', '한rD', 'THR22', 'F_ou_r', 'five']),
-      ).toThrow(PostInputInvalidException);
-    });
-
-    it('각 태그의 시작에 언더바가 있다면 예외를 반환한다', () => {
-      expect(() =>
-        service.indexPost(post, ['_한글', '한rD', 'THR22', 'F_ou_r', 'five']),
-      ).toThrow(PostInputInvalidException);
-    });
-
-    it('각 태그의 끝에 언더바가 있다면 예외를 반환한다', () => {
-      expect(() =>
-        service.indexPost(post, ['한글_', '한rD', 'THR22', 'F_ou_r', 'five']),
-      ).toThrow(PostInputInvalidException);
-    });
-
-    // 언더바가 연속으로 들어간 경우 -> 예외
-
-    it('태그 중 10글자를 넘는 값이 있다면 예외를 반환한다', () => {
-      expect(() => service.indexPost(post, ['12345678901'])).toThrow(
-        PostInputInvalidException,
-      );
+        service.indexPost(post, [' one', 'two', 'thre e', 'four']),
+      ).toThrow(TagInvalidException);
     });
   });
 
@@ -201,22 +231,6 @@ describe('PostSearchService', () => {
     });
 
     describe('입력값 검증', () => {
-      it('lastId가 없어도, 정상적으로 동작한다', async () => {
-        delete searchCondition.lastId;
-
-        await service.search(searchCondition);
-
-        expect(esService.search).toBeCalled();
-        expect(esService.search).toBeCalledWith(searchConditionUsingES);
-      });
-
-      it('필터링 조건이 하나도 들어가지 않을 때 정상적으로 동작한다', async () => {
-        await service.search(searchCondition);
-
-        expect(esService.search).toBeCalled();
-        expect(esService.search).toBeCalledWith(searchConditionUsingES);
-      });
-
       it('tags가 한 개 들어왔을 때, 정상 출력한다', async () => {
         //given
         searchCondition.tags = ['one'];
@@ -262,9 +276,67 @@ describe('PostSearchService', () => {
 
           //when
           await service.search(searchCondition);
+          throw new Error();
         } catch (err) {
           //then
           expect(err).toBeInstanceOf(SearchParamInvalidException);
+        }
+      });
+
+      it('태그 하나의 글자수가 30개면 정상 동작한다', async () => {
+        //given
+        searchCondition.tags = [
+          '부스트캠프부스트캠프부스트캠프부스트캠프부스트캠프부스트캠프',
+        ];
+
+        //when
+        await service.search(searchCondition);
+
+        expect(esService.search).toBeCalled();
+      });
+
+      it('태그 하나의 글자수가 31개면 예외를 반환한다', async () => {
+        try {
+          //given
+          searchCondition.tags = [
+            '부스트캠프부스트캠프부스트캠프부스트캠프부스트캠프부스트캠프1',
+          ];
+
+          //when
+          await service.search(searchCondition);
+          console.log('rerererer', searchCondition);
+          throw new Error();
+        } catch (err) {
+          //then
+          expect(err).toBeInstanceOf(TagInvalidException);
+        }
+      });
+
+      it('아무 값도 들어있지 않은 태그가 있으면 예외를 반환한다', async () => {
+        try {
+          //given
+          searchCondition.tags = ['one', '   ', 'three', 'four', 'five'];
+
+          //when
+          await service.search(searchCondition);
+          throw new Error();
+        } catch (err) {
+          //then
+          expect(err).toBeInstanceOf(TagInvalidException);
+        }
+      });
+
+      it('공백이 포함된 태그가 있으면 예외를 반환한다', async () => {
+        try {
+          //given
+          searchCondition.tags = [' one', 'two', 'thre e', 'four'];
+
+          //when
+          await service.search(searchCondition);
+          throw new Error();
+        } catch (err) {
+          //then
+          expect(err).toBeInstanceOf(TagInvalidException);
         }
       });
 
@@ -277,7 +349,7 @@ describe('PostSearchService', () => {
         searchCondition.details = ['hello my name is taehoon kim'];
         searchConditionUsingES.body.query.bool.filter.bool.must.push({
           multi_match: {
-            query: searchCondition.details,
+            query: searchCondition.details[0],
             fields: ['title', 'content', 'code', 'language', 'authorNickname'],
           },
         });
@@ -300,6 +372,7 @@ describe('PostSearchService', () => {
           ];
           //when
           await service.search(searchCondition);
+          throw new Error();
         } catch (err) {
           expect(err).toBeInstanceOf(SearchParamInvalidException);
         }
@@ -312,6 +385,7 @@ describe('PostSearchService', () => {
           searchCondition.reviewCount = -1;
           //when
           await service.search(searchCondition);
+          throw new Error();
         } catch (err) {
           expect(err).toBeInstanceOf(SearchParamInvalidException);
         }
@@ -323,9 +397,46 @@ describe('PostSearchService', () => {
           searchCondition.reviewCount = 21;
           //when
           await service.search(searchCondition);
+          throw new Error();
         } catch (err) {
           expect(err).toBeInstanceOf(SearchParamInvalidException);
         }
+      });
+
+      it('reviewCount가 1개일 때 정상 출력한다', async () => {
+        //given
+        searchCondition.reviewCount = 1;
+        searchConditionUsingES.body.query.bool.filter.bool.must.push({
+          range: {
+            reviewCount: {
+              gte: searchCondition.reviewCount,
+            },
+          },
+        });
+
+        //when
+        await service.search(searchCondition);
+
+        expect(esService.search).toBeCalled();
+        expect(esService.search).toBeCalledWith(searchConditionUsingES);
+      });
+
+      it('likeCount 1개일 때 정상 출력한다', async () => {
+        //given
+        searchCondition.likeCount = 1;
+        searchConditionUsingES.body.query.bool.filter.bool.must.push({
+          range: {
+            likeCount: {
+              gte: searchCondition.likeCount,
+            },
+          },
+        });
+
+        //when
+        await service.search(searchCondition);
+
+        expect(esService.search).toBeCalled();
+        expect(esService.search).toBeCalledWith(searchConditionUsingES);
       });
 
       it('likeCount가 음수면, 예외를 반환한다', async () => {
@@ -334,6 +445,7 @@ describe('PostSearchService', () => {
           searchCondition.likeCount = -1;
           //when
           await service.search(searchCondition);
+          throw new Error();
         } catch (err) {
           expect(err).toBeInstanceOf(SearchParamInvalidException);
         }
@@ -345,8 +457,92 @@ describe('PostSearchService', () => {
           searchCondition.likeCount = 21;
           //when
           await service.search(searchCondition);
+          throw new Error();
         } catch (err) {
           expect(err).toBeInstanceOf(SearchParamInvalidException);
+        }
+      });
+    });
+
+    describe('결과값 검증', () => {
+      it('검색결과가 id로 오름차순 정렬되었을 때, 정상 출력한다', async () => {
+        //given
+        mockElasticSearchService.search = jest.fn().mockResolvedValue({
+          hits: {
+            hits: [
+              { _source: { id: 1 } },
+              { _source: { id: 2 } },
+              { _source: { id: 3 } },
+            ],
+          },
+        });
+        //when
+        const result = await service.search(searchCondition);
+
+        //then
+        expect(result).toStrictEqual([
+          { _source: { id: 1 } },
+          { _source: { id: 2 } },
+          { _source: { id: 3 } },
+        ]);
+      });
+
+      it('검색결과가 id로 오름차순 정렬되지 않았을 때, 예외를 반환한다', async () => {
+        try {
+          mockElasticSearchService.search = jest.fn().mockResolvedValue({
+            hits: {
+              hits: [
+                { _source: { id: 4 } },
+                { _source: { id: 2 } },
+                { _source: { id: 3 } },
+              ],
+            },
+          });
+          //when
+          await service.search(searchCondition);
+          throw new Error();
+        } catch (err) {
+          expect(err).toBeInstanceOf(SearchResponseInvalidException);
+        }
+      });
+
+      it('N+1개 보다 많은 결과가 오면, 예외를 반환한다', async () => {
+        try {
+          mockElasticSearchService.search = jest.fn().mockResolvedValue({
+            hits: {
+              hits: [
+                { _source: { id: 1 } },
+                { _source: { id: 2 } },
+                { _source: { id: 3 } },
+                { _source: { id: 4 } },
+                { _source: { id: 5 } },
+              ],
+            },
+          });
+          //when
+          await service.search(searchCondition);
+          throw new Error();
+        } catch (err) {
+          expect(err).toBeInstanceOf(SearchResponseInvalidException);
+        }
+      });
+
+      it('결과값에 중복되는 아이디가 있으면 예외를 반환한다', async () => {
+        try {
+          mockElasticSearchService.search = jest.fn().mockResolvedValue({
+            hits: {
+              hits: [
+                { _source: { id: 1 } },
+                { _source: { id: 1 } },
+                { _source: { id: 3 } },
+              ],
+            },
+          });
+          //when
+          await service.search(searchCondition);
+          throw new Error();
+        } catch (err) {
+          expect(err).toBeInstanceOf(SearchResponseInvalidException);
         }
       });
     });

--- a/server/src/domain/post/post-search.service.spec.ts
+++ b/server/src/domain/post/post-search.service.spec.ts
@@ -3,19 +3,32 @@ import { ConfigService } from '@nestjs/config';
 import { Test, TestingModule } from '@nestjs/testing';
 import { PostSearchService } from './post-search.service';
 import { LoadPostListRequestDto } from './dto/service-request.dto';
+import { Post } from './post.entity';
+import { User } from '../user/user.entity';
+import { PostNotFoundException } from '../../exception/post-not-found.exception';
+import { PostInputInvalidException } from '../../exception/post-input-invalid.exception';
+import { SEND_POST_CNT } from './post.controller';
+import { SearchParamInvalidException } from '../../exception/search-param-invalid.exception';
 
 const mockElasticSearchService = {
+  //TODO 위로 옮겨가도 테스트 할때마다 초기화가 될까?
   index: jest.fn(),
-  search: jest.fn(),
+  search: jest.fn().mockResolvedValue({
+    hits: {
+      hits: {},
+    },
+  }),
 };
 const mockConfigService = {
-  get: jest.fn(),
+  get: jest.fn(() => '엘라스틱_인덱스명'),
 };
 
 describe('PostSearchService', () => {
   let service: PostSearchService;
   let esService: ElasticsearchService;
   let configService: ConfigService;
+
+  let post: Post;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -36,6 +49,23 @@ describe('PostSearchService', () => {
     service = module.get<PostSearchService>(PostSearchService);
     esService = module.get<ElasticsearchService>(ElasticsearchService);
     configService = module.get<ConfigService>(ConfigService);
+
+    const user = new User();
+    user.id = 10;
+    user.nickname = '사용자이름';
+
+    post = new Post();
+    post.id = 1;
+    post.title = '제목';
+    post.content = 'content';
+    post.code = 'System.out.println("zz")';
+    post.language = 'java';
+    post.createdAt = new Date();
+    post.updatedAt = new Date();
+    post.user = user;
+    post.lineCount = 1;
+    post.reviewCount = 0;
+    post.likeCount = 0;
   });
 
   it('should be defined', () => {
@@ -44,160 +74,280 @@ describe('PostSearchService', () => {
 
   describe('저장', () => {
     it('게시물이 들어오지 않으면 예외를 반환한다', () => {
-      //
+      expect(() => {
+        service.indexPost(null, ['greedy', 'sort']);
+      }).toThrow(PostNotFoundException);
     });
 
     it('게시물이 1개 들어오면 정상적으로 동작한다', () => {
-      //
-    });
-
-    it('게시물이 1개 넘게 들어오면 예외를 반환한다', () => {
-      //
+      service.indexPost(post, ['greedy', 'sort']);
+      expect(esService.index).toBeCalled();
+      // TODO 내부 값 테스트
     });
 
     it('태그가 0개 들어오면 정상 동작한다', () => {
-      //
+      service.indexPost(post, []);
+      expect(esService.index).toBeCalled();
     });
 
     it('태그가 1개 들어오면 정상 동작한다', () => {
-      //
+      service.indexPost(post, ['one']);
+      expect(esService.index).toBeCalled();
     });
 
     it('태그가 5개 들어오면 정상 동작한다', () => {
-      //
+      service.indexPost(post, ['one', 'two', 'three', 'four', 'five']);
+      expect(esService.index).toBeCalled();
+    });
+
+    it('중복된 태그가 들어오면 예외를 반환한다', () => {
+      expect(() =>
+        service.indexPost(post, ['one', 'two', 'three', 'two', 'five']),
+      ).toThrow(PostInputInvalidException);
     });
 
     it('태그가 6개 들어오면 예외를 반환한다', () => {
-      //
+      expect(() =>
+        service.indexPost(post, ['one', 'two', 'three', 'four', 'five', 'six']),
+      ).toThrow(PostInputInvalidException);
+    });
+
+    // TODO 태그를 객체로 분리하기
+    it('태그 중 10글자까지는 정상 동작한다', () => {
+      service.indexPost(post, ['가나다라마바사아자카']);
+      expect(esService.index).toBeCalled();
+    });
+
+    it('공백만 들어간 태그가 있으면 예외를 반환한다', () => {
+      expect(() =>
+        service.indexPost(post, ['one', '   ', 'three', 'four', 'five']),
+      ).toThrow(PostInputInvalidException);
+    });
+
+    it('한글, 영대소문자, 숫자, 언더바 이외의 문자(#로 테스트)가 들어간 태그가 있으면 예외를 반환한다', () => {
+      expect(() =>
+        service.indexPost(post, ['one', 'two', '#three', 'four']),
+      ).toThrow(PostInputInvalidException);
+    });
+
+    it('한글, 영대소문자, 숫자, 언더바 이외의 문자가 들어간 태그(공백으로 테스트)가 있으면 예외를 반환한다', () => {
+      expect(() =>
+        service.indexPost(post, [' one', 'two', 'thre@e', 'four']),
+      ).toThrow(PostInputInvalidException);
+    });
+
+    it('각 태그에 한글, 영대소문자, 숫자, 언더바만 들어가면 정상 동작한다', () => {
+      expect(() =>
+        service.indexPost(post, ['한글', '한rD', 'THR22', 'F_ou_r', 'five']),
+      ).toThrow(PostInputInvalidException);
+    });
+
+    it('각 태그의 시작에 언더바가 있다면 예외를 반환한다', () => {
+      expect(() =>
+        service.indexPost(post, ['_한글', '한rD', 'THR22', 'F_ou_r', 'five']),
+      ).toThrow(PostInputInvalidException);
+    });
+
+    it('각 태그의 끝에 언더바가 있다면 예외를 반환한다', () => {
+      expect(() =>
+        service.indexPost(post, ['한글_', '한rD', 'THR22', 'F_ou_r', 'five']),
+      ).toThrow(PostInputInvalidException);
+    });
+
+    // 언더바가 연속으로 들어간 경우 -> 예외
+
+    it('태그 중 10글자를 넘는 값이 있다면 예외를 반환한다', () => {
+      expect(() => service.indexPost(post, ['12345678901'])).toThrow(
+        PostInputInvalidException,
+      );
     });
   });
 
   describe('검색', () => {
     let searchCondition: LoadPostListRequestDto;
+    let searchConditionUsingES;
+
     beforeEach(() => {
+      searchConditionUsingES = {
+        sort: [
+          {
+            id: {
+              order: 'DESC',
+            },
+          },
+        ],
+        size: SEND_POST_CNT + 1,
+        index: configService.get(''),
+        body: {
+          query: {
+            bool: {
+              filter: {
+                bool: {
+                  must: [],
+                },
+              },
+            },
+          },
+        },
+      };
+
       searchCondition = {
-        lastId: 1,
+        lastId: -1,
         tags: [],
-        reviewCount: 1,
-        likeCount: 1,
+        reviewCount: 0,
+        likeCount: 0,
         details: [],
       };
     });
 
     describe('입력값 검증', () => {
       it('lastId가 없어도, 정상적으로 동작한다', async () => {
-        //
+        delete searchCondition.lastId;
+
+        await service.search(searchCondition);
+
+        expect(esService.search).toBeCalled();
+        expect(esService.search).toBeCalledWith(searchConditionUsingES);
       });
 
-      it('tags가 비어 있을 때, 정상 출력한다', async () => {
-        //
+      it('필터링 조건이 하나도 들어가지 않을 때 정상적으로 동작한다', async () => {
+        await service.search(searchCondition);
+
+        expect(esService.search).toBeCalled();
+        expect(esService.search).toBeCalledWith(searchConditionUsingES);
       });
 
       it('tags가 한 개 들어왔을 때, 정상 출력한다', async () => {
-        //
+        //given
+        searchCondition.tags = ['one'];
+        searchConditionUsingES.body.query.bool.filter.bool.must.push({
+          match: {
+            tags: {
+              query: 'one',
+              operator: 'AND',
+            },
+          },
+        });
+
+        //when
+        await service.search(searchCondition);
+
+        expect(esService.search).toBeCalled();
+        expect(esService.search).toBeCalledWith(searchConditionUsingES);
       });
 
       it('tags가 다섯 개 들어왔을 때, 정상 출력한다', async () => {
-        //
+        //given
+        searchCondition.tags = ['one', 'two', 'three', 'four', 'five'];
+        searchConditionUsingES.body.query.bool.filter.bool.must.push({
+          match: {
+            tags: {
+              query: ['one', 'two', 'three', 'four', 'five'].join(' '),
+              operator: 'AND',
+            },
+          },
+        });
+
+        //when
+        await service.search(searchCondition);
+
+        expect(esService.search).toBeCalled();
+        expect(esService.search).toBeCalledWith(searchConditionUsingES);
       });
 
       it('tags가 여섯 개 들어왔을 때, 예외를 반환한다', async () => {
-        //
+        try {
+          //given
+          searchCondition.tags = ['one', 'two', 'three', 'four', 'five', 'six'];
+
+          //when
+          await service.search(searchCondition);
+        } catch (err) {
+          //then
+          expect(err).toBeInstanceOf(SearchParamInvalidException);
+        }
       });
 
-      it('tags가 여섯 개 들어왔을 때, 예외를 반환한다', async () => {
-        //
-      });
-      it('details가 비어있을 때, 정상 출력한다', async () => {
-        //
+      it('details에 공백이 넘어올 때, 정상 출력한다', async () => {
+        //TODO 놓친 케이스. 프론트에서 막아줄건지, 백엔드에서 무시할건지 이야기
       });
 
       it('details가 1개일 때, 정상 출력한다', async () => {
-        //
+        //given
+        searchCondition.details = ['hello my name is taehoon kim'];
+        searchConditionUsingES.body.query.bool.filter.bool.must.push({
+          multi_match: {
+            query: searchCondition.details,
+            fields: ['title', 'content', 'code', 'language', 'authorNickname'],
+          },
+        });
+
+        //when
+        await service.search(searchCondition);
+
+        expect(esService.search).toBeCalled();
+        expect(esService.search).toBeCalledWith(searchConditionUsingES);
       });
+
+      // TODO 검색어 길이 제한
 
       it('details가 1개를 넘어가면, 예외를 반환한다', async () => {
-        //
+        try {
+          //given
+          searchCondition.details = [
+            'hello my name is taehoon kim',
+            'second value',
+          ];
+          //when
+          await service.search(searchCondition);
+        } catch (err) {
+          expect(err).toBeInstanceOf(SearchParamInvalidException);
+        }
       });
 
+      //ddd
       it('reviewCount가 음수면, 예외를 반환한다', async () => {
-        //
+        try {
+          //given
+          searchCondition.reviewCount = -1;
+          //when
+          await service.search(searchCondition);
+        } catch (err) {
+          expect(err).toBeInstanceOf(SearchParamInvalidException);
+        }
       });
 
       it('reviewCount가 20보다 크면, 예외를 반환한다', async () => {
-        //
+        try {
+          //given
+          searchCondition.reviewCount = 21;
+          //when
+          await service.search(searchCondition);
+        } catch (err) {
+          expect(err).toBeInstanceOf(SearchParamInvalidException);
+        }
       });
 
-      it('likesCount가 음수면, 예외를 반환한다', async () => {
-        //
+      it('likeCount가 음수면, 예외를 반환한다', async () => {
+        try {
+          //given
+          searchCondition.likeCount = -1;
+          //when
+          await service.search(searchCondition);
+        } catch (err) {
+          expect(err).toBeInstanceOf(SearchParamInvalidException);
+        }
       });
 
-      it('likesCount가 20보다 크면, 예외를 반환한다', async () => {
-        //
-      });
-    });
-    describe('결과값 검증', () => {
-      it('검색결과가 id로 오름차순 정렬되었을 때, 정상 출력한다', async () => {
-        //given
-
-        //when
-        const result = await service.search(searchCondition);
-
-        //then
-      });
-
-      it('검색결과가 id로 오름차순 정렬되지 않았을 때, 예외를 반환한다', async () => {
-        //given
-
-        //when
-        const result = await service.search(searchCondition);
-
-        //then
-      });
-
-      it('N+1개의 결과가 오면, posts를 3개 반환하고 isLast를 false로 반환한다', async () => {
-        //given
-
-        //when
-        const result = await service.search(searchCondition);
-
-        //then
-      });
-
-      it('N개의 결과가 오면, posts를 N개 반환하고 isLast를 true로 반환한다', async () => {
-        //given
-
-        //when
-        const result = await service.search(searchCondition);
-
-        //then
-      });
-
-      it('0개의 결과가 오면, posts를 0개 반환하고 isLast를 true로 반환한다', async () => {
-        //given
-
-        //when
-        const result = await service.search(searchCondition);
-
-        //then
-      });
-
-      it('N+1개 보다 많은 결과가 오면, 예외를 반환한다', async () => {
-        //given
-
-        //when
-        const result = await service.search(searchCondition);
-
-        //then
-      });
-
-      it('결과값에 중복되는 아이디가 있으면 예외를 반환한다', async () => {
-        //given
-
-        //when
-        const result = await service.search(searchCondition);
-
-        //then
+      it('likeCount가 20보다 크면, 예외를 반환한다', async () => {
+        try {
+          //given
+          searchCondition.likeCount = 21;
+          //when
+          await service.search(searchCondition);
+        } catch (err) {
+          expect(err).toBeInstanceOf(SearchParamInvalidException);
+        }
       });
     });
   });

--- a/server/src/domain/post/post-search.service.spec.ts
+++ b/server/src/domain/post/post-search.service.spec.ts
@@ -1,0 +1,204 @@
+import { ElasticsearchService } from '@nestjs/elasticsearch';
+import { ConfigService } from '@nestjs/config';
+import { Test, TestingModule } from '@nestjs/testing';
+import { PostSearchService } from './post-search.service';
+import { LoadPostListRequestDto } from './dto/service-request.dto';
+
+const mockElasticSearchService = {
+  index: jest.fn(),
+  search: jest.fn(),
+};
+const mockConfigService = {
+  get: jest.fn(),
+};
+
+describe('PostSearchService', () => {
+  let service: PostSearchService;
+  let esService: ElasticsearchService;
+  let configService: ConfigService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        PostSearchService,
+        ElasticsearchService,
+        ConfigService,
+        {
+          provide: ElasticsearchService,
+          useValue: mockElasticSearchService,
+        },
+        {
+          provide: ConfigService,
+          useValue: mockConfigService,
+        },
+      ],
+    }).compile();
+    service = module.get<PostSearchService>(PostSearchService);
+    esService = module.get<ElasticsearchService>(ElasticsearchService);
+    configService = module.get<ConfigService>(ConfigService);
+  });
+
+  it('should be defined', () => {
+    expect(esService).toBeDefined();
+  });
+
+  describe('저장', () => {
+    it('게시물이 들어오지 않으면 예외를 반환한다', () => {
+      //
+    });
+
+    it('게시물이 1개 들어오면 정상적으로 동작한다', () => {
+      //
+    });
+
+    it('게시물이 1개 넘게 들어오면 예외를 반환한다', () => {
+      //
+    });
+
+    it('태그가 0개 들어오면 정상 동작한다', () => {
+      //
+    });
+
+    it('태그가 1개 들어오면 정상 동작한다', () => {
+      //
+    });
+
+    it('태그가 5개 들어오면 정상 동작한다', () => {
+      //
+    });
+
+    it('태그가 6개 들어오면 예외를 반환한다', () => {
+      //
+    });
+  });
+
+  describe('검색', () => {
+    let searchCondition: LoadPostListRequestDto;
+    beforeEach(() => {
+      searchCondition = {
+        lastId: 1,
+        tags: [],
+        reviewCount: 1,
+        likeCount: 1,
+        details: [],
+      };
+    });
+
+    describe('입력값 검증', () => {
+      it('lastId가 없어도, 정상적으로 동작한다', async () => {
+        //
+      });
+
+      it('tags가 비어 있을 때, 정상 출력한다', async () => {
+        //
+      });
+
+      it('tags가 한 개 들어왔을 때, 정상 출력한다', async () => {
+        //
+      });
+
+      it('tags가 다섯 개 들어왔을 때, 정상 출력한다', async () => {
+        //
+      });
+
+      it('tags가 여섯 개 들어왔을 때, 예외를 반환한다', async () => {
+        //
+      });
+
+      it('tags가 여섯 개 들어왔을 때, 예외를 반환한다', async () => {
+        //
+      });
+      it('details가 비어있을 때, 정상 출력한다', async () => {
+        //
+      });
+
+      it('details가 1개일 때, 정상 출력한다', async () => {
+        //
+      });
+
+      it('details가 1개를 넘어가면, 예외를 반환한다', async () => {
+        //
+      });
+
+      it('reviewCount가 음수면, 예외를 반환한다', async () => {
+        //
+      });
+
+      it('reviewCount가 20보다 크면, 예외를 반환한다', async () => {
+        //
+      });
+
+      it('likesCount가 음수면, 예외를 반환한다', async () => {
+        //
+      });
+
+      it('likesCount가 20보다 크면, 예외를 반환한다', async () => {
+        //
+      });
+    });
+    describe('결과값 검증', () => {
+      it('검색결과가 id로 오름차순 정렬되었을 때, 정상 출력한다', async () => {
+        //given
+
+        //when
+        const result = await service.search(searchCondition);
+
+        //then
+      });
+
+      it('검색결과가 id로 오름차순 정렬되지 않았을 때, 예외를 반환한다', async () => {
+        //given
+
+        //when
+        const result = await service.search(searchCondition);
+
+        //then
+      });
+
+      it('N+1개의 결과가 오면, posts를 3개 반환하고 isLast를 false로 반환한다', async () => {
+        //given
+
+        //when
+        const result = await service.search(searchCondition);
+
+        //then
+      });
+
+      it('N개의 결과가 오면, posts를 N개 반환하고 isLast를 true로 반환한다', async () => {
+        //given
+
+        //when
+        const result = await service.search(searchCondition);
+
+        //then
+      });
+
+      it('0개의 결과가 오면, posts를 0개 반환하고 isLast를 true로 반환한다', async () => {
+        //given
+
+        //when
+        const result = await service.search(searchCondition);
+
+        //then
+      });
+
+      it('N+1개 보다 많은 결과가 오면, 예외를 반환한다', async () => {
+        //given
+
+        //when
+        const result = await service.search(searchCondition);
+
+        //then
+      });
+
+      it('결과값에 중복되는 아이디가 있으면 예외를 반환한다', async () => {
+        //given
+
+        //when
+        const result = await service.search(searchCondition);
+
+        //then
+      });
+    });
+  });
+});

--- a/server/src/domain/post/post-search.service.spec.ts
+++ b/server/src/domain/post/post-search.service.spec.ts
@@ -465,14 +465,14 @@ describe('PostSearchService', () => {
     });
 
     describe('결과값 검증', () => {
-      it('검색결과가 id로 오름차순 정렬되었을 때, 정상 출력한다', async () => {
+      it('검색결과가 id로 내림차순 정렬되었을 때, 정상 출력한다', async () => {
         //given
         mockElasticSearchService.search = jest.fn().mockResolvedValue({
           hits: {
             hits: [
-              { _source: { id: 1 } },
-              { _source: { id: 2 } },
               { _source: { id: 3 } },
+              { _source: { id: 2 } },
+              { _source: { id: 1 } },
             ],
           },
         });
@@ -481,13 +481,13 @@ describe('PostSearchService', () => {
 
         //then
         expect(result).toStrictEqual([
-          { _source: { id: 1 } },
-          { _source: { id: 2 } },
           { _source: { id: 3 } },
+          { _source: { id: 2 } },
+          { _source: { id: 1 } },
         ]);
       });
 
-      it('검색결과가 id로 오름차순 정렬되지 않았을 때, 예외를 반환한다', async () => {
+      it('검색결과가 id로 내림차순 정렬되지 않았을 때, 예외를 반환한다', async () => {
         try {
           mockElasticSearchService.search = jest.fn().mockResolvedValue({
             hits: {
@@ -511,11 +511,11 @@ describe('PostSearchService', () => {
           mockElasticSearchService.search = jest.fn().mockResolvedValue({
             hits: {
               hits: [
-                { _source: { id: 1 } },
-                { _source: { id: 2 } },
-                { _source: { id: 3 } },
-                { _source: { id: 4 } },
                 { _source: { id: 5 } },
+                { _source: { id: 4 } },
+                { _source: { id: 3 } },
+                { _source: { id: 2 } },
+                { _source: { id: 1 } },
               ],
             },
           });
@@ -532,9 +532,9 @@ describe('PostSearchService', () => {
           mockElasticSearchService.search = jest.fn().mockResolvedValue({
             hits: {
               hits: [
-                { _source: { id: 1 } },
-                { _source: { id: 1 } },
                 { _source: { id: 3 } },
+                { _source: { id: 1 } },
+                { _source: { id: 1 } },
               ],
             },
           });

--- a/server/src/domain/post/post-search.service.ts
+++ b/server/src/domain/post/post-search.service.ts
@@ -1,0 +1,104 @@
+import { Injectable } from '@nestjs/common';
+import { ElasticsearchService } from '@nestjs/elasticsearch';
+import { Post } from './post.entity';
+import { LoadPostListRequestDto } from './dto/service-request.dto';
+import { SEND_POST_CNT } from './post.controller';
+
+@Injectable()
+export class PostSearchService {
+  constructor(private readonly esService: ElasticsearchService) {}
+
+  async indexPost(post: Post, tags: any) {
+    // 태그를 정렬해 넣는다.
+    let tagValue = '';
+    if (tags) {
+      tags.sort();
+      tagValue = tags.join(' ');
+    }
+    const x = await this.esService.index<PostSearchBody>({
+      index: 'test', //TODO 이름 임시
+      body: {
+        id: post.id,
+        title: post.title,
+        content: post.content,
+        code: post.code,
+        language: post.language,
+        createdAt: post.createdAt,
+        updatedAt: post.updatedAt,
+        authorId: post.user.id,
+        authorNickname: post.user.nickname,
+        tags: tagValue,
+        lineCount: post.lineCount,
+      },
+    });
+    console.log('indexPost ', x);
+  }
+
+  async search(loadPostListRequestDto: LoadPostListRequestDto) {
+    const { lastId, tags, reviewCount, likeCount, details } =
+      loadPostListRequestDto;
+    const searchFilter: any = {
+      sort: [
+        {
+          createdAt: {
+            order: 'desc',
+          },
+        },
+      ],
+      size: SEND_POST_CNT + 1,
+      index: 'test', // TODO 최신순 3개
+      body: {
+        query: {
+          bool: {
+            filter: {
+              bool: {
+                must: [],
+              },
+            },
+          },
+        },
+      },
+    };
+    if (lastId !== -1) {
+      searchFilter.from = lastId;
+    }
+
+    if (details && details.length > 0) {
+      // const q = details.length == 1 ? details : details.join(' ');
+      // console.log(q);
+      for (const detail of details) {
+        searchFilter.body.query.bool.filter.bool.must.push({
+          multi_match: {
+            query: detail,
+            fields: [
+              'title',
+              'content',
+              'code',
+              'language',
+              'authorNickname',
+              'tags',
+            ],
+          },
+        });
+      }
+    }
+    if (tags && tags.length > 0) {
+      const q = tags.length == 1 ? tags : tags.join(' ');
+      searchFilter.body.query.bool.filter.bool.must.push({
+        match: {
+          tags: {
+            query: q,
+            operator: 'AND',
+          },
+        },
+      });
+    }
+
+    const body = await this.esService.search<PostSearchResult>(searchFilter);
+    // TODO 이따 searchFilter로 내용 갈아끼기
+    const result = body.hits.hits;
+    console.log('hits', result); //결과
+
+    return result;
+  }
+}

--- a/server/src/domain/post/post-search.service.ts
+++ b/server/src/domain/post/post-search.service.ts
@@ -155,11 +155,11 @@ export class PostSearchService {
         '중복되는 결과가 반환되었습니다',
       );
     }
-    let min = 0;
+    let min = 21000000;
     for (const id of ids) {
-      if (min >= id) {
+      if (min < id) {
         throw new SearchResponseInvalidException(
-          '결과가 오름차순 정렬되지 않았습니다',
+          '결과가 내림차순 정렬되지 않았습니다',
         );
       }
       min = id;

--- a/server/src/domain/post/post-search.service.ts
+++ b/server/src/domain/post/post-search.service.ts
@@ -49,7 +49,7 @@ export class PostSearchService {
         },
       ],
       size: SEND_POST_CNT + 1,
-      index: 'test', // TODO 최신순 3개
+      index: 'test', // TODO 이름 임시
       body: {
         query: {
           bool: {
@@ -71,24 +71,23 @@ export class PostSearchService {
         searchFilter.body.query.bool.filter.bool.must.push({
           multi_match: {
             query: detail,
-            fields: [
-              'title',
-              'content',
-              'code',
-              'language',
-              'authorNickname',
-              'tags',
-            ],
+            fields: ['title', 'content', 'code', 'language', 'authorNickname'],
           },
         });
       }
     }
+
     if (tags && tags.length > 0) {
-      const q = tags.length == 1 ? tags : tags.join(' ');
+      const q =
+        tags.length == 1
+          ? `/"${tags}/"`
+          : tags.map((tag) => `/"${tag}/"`).join(' ');
+      console.log(q);
       searchFilter.body.query.bool.filter.bool.must.push({
         match: {
           tags: {
             query: q,
+
             operator: 'AND',
           },
         },
@@ -113,6 +112,7 @@ export class PostSearchService {
       });
     }
     const body = await this.esService.search<PostSearchResult>(searchFilter);
+    console.log(body.hits.hits);
     return body.hits.hits;
   }
 }

--- a/server/src/domain/post/post-search.service.ts
+++ b/server/src/domain/post/post-search.service.ts
@@ -31,6 +31,7 @@ export class PostSearchService {
         authorNickname: post.user.nickname,
         tags: tagValue,
         lineCount: post.lineCount,
+        reviewCount: post.reviewCount,
         likeCount: post.likeCount,
       },
     });

--- a/server/src/domain/post/post-search.service.ts
+++ b/server/src/domain/post/post-search.service.ts
@@ -18,7 +18,6 @@ export class PostSearchService {
 
     this.esService.index<PostSearchBody>({
       index: 'test', //TODO 이름 임시
-      id: String(post.id),
       body: {
         id: post.id,
         title: post.title,
@@ -63,7 +62,7 @@ export class PostSearchService {
       },
     };
     if (lastId !== -1) {
-      searchFilter.from = lastId;
+      searchFilter.search_after = [lastId];
     }
 
     if (details && details.length > 0) {
@@ -82,7 +81,6 @@ export class PostSearchService {
         tags.length == 1
           ? `/"${tags}/"`
           : tags.map((tag) => `/"${tag}/"`).join(' ');
-      console.log(q);
       searchFilter.body.query.bool.filter.bool.must.push({
         match: {
           tags: {

--- a/server/src/domain/post/post-search.service.ts
+++ b/server/src/domain/post/post-search.service.ts
@@ -82,9 +82,10 @@ export class PostSearchService {
 
     if (tags && tags.length > 0) {
       const q =
-        tags.length == 1
-          ? `/"${tags}/"`
-          : tags.map((tag) => `/"${tag}/"`).join(' ');
+        typeof tags === 'string'
+          ? `${tags}`
+          : tags.map((tag) => `${tag}`).join(' ');
+
       searchFilter.body.query.bool.filter.bool.must.push({
         match: {
           tags: {

--- a/server/src/domain/post/post-search.service.ts
+++ b/server/src/domain/post/post-search.service.ts
@@ -116,6 +116,7 @@ export class PostSearchService {
     }
 
     const body = await this.esService.search<PostSearchResult>(searchFilter);
+    console.log(body.hits.hits[0]);
     return body.hits.hits;
   }
 }

--- a/server/src/domain/post/post-search.service.ts
+++ b/server/src/domain/post/post-search.service.ts
@@ -4,6 +4,21 @@ import { Post } from './post.entity';
 import { LoadPostListRequestDto } from './dto/service-request.dto';
 import { SEND_POST_CNT } from './post.controller';
 import { ConfigService } from '@nestjs/config';
+import { PostNotFoundException } from '../../exception/post-not-found.exception';
+import { PostInputInvalidException } from '../../exception/post-input-invalid.exception';
+import { SearchParamInvalidException } from '../../exception/search-param-invalid.exception';
+import { SearchHit } from '@elastic/elasticsearch/lib/api/types';
+import { SearchResponseInvalidException } from '../../exception/search-response-invalid.exception';
+import { TagInvalidException } from '../../exception/tag-invalid.exception';
+
+const MAX_TAG_COUNT = 5; // TODO 상수 클래스 지정
+
+const MIN_LIKES_FILTERING_COUNT = 0;
+const MIN_REVIEW_FILTERING_COUNT = 0;
+const MAX_LIKES_FILTERING_COUNT = 20;
+const MAX_REVIEW_FILTERING_COUNT = 20;
+
+const MAX_TAG_LENGTH = 30;
 
 @Injectable()
 export class PostSearchService {
@@ -12,11 +27,19 @@ export class PostSearchService {
     private readonly configService: ConfigService,
   ) {}
 
-  async indexPost(post: Post, tags: any) {
+  indexPost(post: Post, tags: string[]) {
+    if (!post) {
+      throw new PostNotFoundException();
+    }
+
+    if (tags.length > MAX_TAG_COUNT) {
+      throw new PostInputInvalidException('태그의 개수가 적절하지 않습니다');
+    }
+    tags.map((tag) => tag.trim()).forEach((tag) => this.validateTag(tag));
+
     let tagValue = '';
     if (tags) {
-      tags.sort();
-      tagValue = tags.join(' ');
+      tagValue = Array.from(new Set(tags)).join(' ');
     }
 
     this.esService.index<PostSearchBody>({
@@ -43,6 +66,8 @@ export class PostSearchService {
   async search(loadPostListRequestDto: LoadPostListRequestDto) {
     const { lastId, tags, reviewCount, likeCount, details } =
       loadPostListRequestDto;
+    this.validateParam(loadPostListRequestDto);
+
     const searchFilter: any = {
       sort: [
         {
@@ -65,19 +90,17 @@ export class PostSearchService {
         },
       },
     };
-    if (lastId !== -1) {
+    if (!(lastId === null || lastId === undefined || lastId === -1)) {
       searchFilter.search_after = [lastId];
     }
 
-    if (details && details.length > 0) {
-      for (const detail of details) {
-        searchFilter.body.query.bool.filter.bool.must.push({
-          multi_match: {
-            query: detail,
-            fields: ['title', 'content', 'code', 'language', 'authorNickname'],
-          },
-        });
-      }
+    if (details.length === 1) {
+      searchFilter.body.query.bool.filter.bool.must.push({
+        multi_match: {
+          query: details[0],
+          fields: ['title', 'content', 'code', 'language', 'authorNickname'],
+        },
+      });
     }
 
     if (tags && tags.length > 0) {
@@ -116,7 +139,74 @@ export class PostSearchService {
     }
 
     const body = await this.esService.search<PostSearchResult>(searchFilter);
-    console.log(body.hits.hits[0]);
+    this.validateReturnValue(body.hits.hits);
     return body.hits.hits;
+  }
+
+  private validateReturnValue(hits: SearchHit<PostSearchResult>[]) {
+    if (hits.length > SEND_POST_CNT + 1) {
+      throw new SearchResponseInvalidException(
+        '너무 많은 검색 결과가 반환되었습니다',
+      );
+    }
+    const ids = hits.map((each) => each._source['id']);
+    if (new Set(ids).size !== ids.length) {
+      throw new SearchResponseInvalidException(
+        '중복되는 결과가 반환되었습니다',
+      );
+    }
+    let min = 0;
+    for (const id of ids) {
+      if (min >= id) {
+        throw new SearchResponseInvalidException(
+          '결과가 오름차순 정렬되지 않았습니다',
+        );
+      }
+      min = id;
+    }
+  }
+
+  private validateParam(loadPostListRequestDto: LoadPostListRequestDto) {
+    const { tags, reviewCount, likeCount, details } = loadPostListRequestDto;
+
+    if (tags.length > MAX_TAG_COUNT) {
+      throw new SearchParamInvalidException('태그의 개수가 적절하지 않습니다');
+    }
+
+    tags.forEach((tag) => this.validateTag(tag));
+    if (
+      reviewCount < MIN_REVIEW_FILTERING_COUNT ||
+      MAX_REVIEW_FILTERING_COUNT < reviewCount
+    ) {
+      throw new SearchParamInvalidException(
+        '선택한 리뷰 개수는 적절하지 않습니다',
+      );
+    }
+    if (
+      likeCount < MIN_LIKES_FILTERING_COUNT ||
+      MAX_LIKES_FILTERING_COUNT < likeCount
+    ) {
+      throw new SearchParamInvalidException(
+        '선택한 리뷰 개수는 적절하지 않습니다',
+      );
+    }
+    if (details.length > 1) {
+      throw new SearchParamInvalidException(
+        '검색어의 개수가 적절하지 않습니다',
+      );
+    }
+  }
+
+  private validateTag(tag: string) {
+    if (tag.includes(' ')) {
+      throw new TagInvalidException('태그 이름은 공백이 올 수 없습니다');
+    }
+
+    if (tag.length === 0) {
+      throw new TagInvalidException('태그는 공백이 올 수 없습니다');
+    }
+    if (tag.length > MAX_TAG_LENGTH) {
+      throw new TagInvalidException('태그의 길이가 너무 깁니다');
+    }
   }
 }

--- a/server/src/domain/post/post.controller.ts
+++ b/server/src/domain/post/post.controller.ts
@@ -78,8 +78,6 @@ export class PostController {
       new LoadPostListRequestDto(lastId, tags, reviewCount, likeCount, details),
     );
 
-    const posts = returnValue.posts;
-
     // TODO 로그인 시 해당 작업 잘 동작하나 검사하기
     await this.addLikesToPostIfLogin(headers['authorization'], returnValue);
     await this.addBookmarksToPostIfLogin(headers['authorization'], returnValue);

--- a/server/src/domain/post/post.controller.ts
+++ b/server/src/domain/post/post.controller.ts
@@ -18,10 +18,6 @@ import {
 import { Request } from 'express';
 import { PostService } from './post.service';
 import {
-  EachPostResponseDto,
-  LoadPostListResponseDto,
-} from './dto/service-response.dto';
-import {
   InquiryDto,
   InquiryPostDto,
   WriteDto,
@@ -47,6 +43,7 @@ import { UserService } from '../user/user.service';
 import { BookmarkService } from '../bookmark/bookmark.service';
 import { HttpService } from '@nestjs/axios';
 import { ConfigService } from '@nestjs/config';
+import { SearchResponseDto } from './dto/controller-response.dto';
 import { BookmarkCreateRequestDto } from '../bookmark/dto/controller-request.dto';
 
 export const SEND_POST_CNT = 3;
@@ -75,14 +72,18 @@ export class PostController {
   async search(
     @Query() inquiryDto: InquiryDto,
     @Headers() headers,
-  ): Promise<LoadPostListResponseDto> {
+  ): Promise<SearchResponseDto> {
     const { tags, lastId, reviewCount, likeCount, details } = inquiryDto;
     const returnValue = await this.postService.loadPostList(
       new LoadPostListRequestDto(lastId, tags, reviewCount, likeCount, details),
     );
-    await this.addLikesCntColumnEveryPosts(returnValue);
+
+    const posts = returnValue.posts;
+
+    // TODO 로그인 시 해당 작업 잘 동작하나 검사하기
     await this.addLikesToPostIfLogin(headers['authorization'], returnValue);
     await this.addBookmarksToPostIfLogin(headers['authorization'], returnValue);
+    await this.addSearchHistory(headers['authorization'], inquiryDto);
 
     await this.addSearchHistory(headers['authorization'], inquiryDto);
 
@@ -91,9 +92,10 @@ export class PostController {
     return returnValue;
   }
 
-  private async addLikesToPostIfLogin(token, result: LoadPostListResponseDto) {
+  private async addLikesToPostIfLogin(token, result: SearchResponseDto) {
     if (token) {
       const userId = this.authService.authenticate(token);
+
       if (userId) {
         const postIdsYouLike = await this.likesService.findPostIdsByUserId(
           userId,
@@ -107,10 +109,7 @@ export class PostController {
     }
   }
 
-  private async addBookmarksToPostIfLogin(
-    token,
-    result: LoadPostListResponseDto,
-  ) {
+  private async addBookmarksToPostIfLogin(token, result: SearchResponseDto) {
     if (token) {
       const userId = this.authService.authenticate(token);
 
@@ -124,17 +123,6 @@ export class PostController {
           }
         });
       }
-    }
-  }
-
-  private async addLikesCntColumnEveryPosts(result: LoadPostListResponseDto) {
-    const ary = [];
-    for (const post of result.posts) {
-      ary.push(this.likesService.countLikesCntByPostId(post.id));
-    }
-    const likesCntStore = await Promise.all(ary);
-    for (let i = 0; i < result.posts.length; i++) {
-      result.posts[i].likesCount = likesCntStore[i];
     }
   }
 
@@ -225,7 +213,7 @@ export class PostController {
   async inquiryPost(
     @Param('postId') postId: number,
     @Headers() header,
-    @Query() requestDto: InquiryPostDto,
+    @Query() requestDto: InquiryPostDto, //TODO 살펴보기
   ) {
     try {
       const returnValue = await this.postService.inquiryPost(postId);

--- a/server/src/domain/post/post.controller.ts
+++ b/server/src/domain/post/post.controller.ts
@@ -73,7 +73,12 @@ export class PostController {
     @Query() inquiryDto: InquiryDto,
     @Headers() headers,
   ): Promise<SearchResponseDto> {
-    const { tags, lastId, reviewCount, likeCount, details } = inquiryDto;
+    const { lastId, reviewCount, likeCount, details } = inquiryDto;
+    let { tags } = inquiryDto;
+    // TODO @Transform을 쓰는게 맞을지, 이게 맞을지 고민하기
+    if (typeof tags === 'string') {
+      tags = [tags];
+    }
     const returnValue = await this.postService.loadPostList(
       new LoadPostListRequestDto(lastId, tags, reviewCount, likeCount, details),
     );

--- a/server/src/domain/post/post.entity.ts
+++ b/server/src/domain/post/post.entity.ts
@@ -45,7 +45,7 @@ export class Post extends BaseTimeEntity {
   likeCount: number;
 
   @Column({ default: 0 })
-  commentCount: number;
+  reviewCount: number;
 
   @Column({ length: 255, default: '[]' })
   tags: string;

--- a/server/src/domain/post/post.entity.ts
+++ b/server/src/domain/post/post.entity.ts
@@ -40,4 +40,16 @@ export class Post extends BaseTimeEntity {
     cascade: ['insert'],
   })
   postToTags: PostToTag[];
+
+  @Column({ default: 0 })
+  likeCount: number;
+
+  @Column({ default: 0 })
+  commentCount: number;
+
+  @Column({ length: 255, default: '[]' })
+  tags: string;
+
+  @Column({ length: 24, default: '' })
+  userNickname: string;
 }

--- a/server/src/domain/post/post.module.ts
+++ b/server/src/domain/post/post.module.ts
@@ -15,6 +15,7 @@ import { UserService } from '../user/user.service';
 import { SearchHistoryMongoRepository } from '../search/search-history.mongo.repository';
 import { BookmarkService } from '../bookmark/bookmark.service';
 import { BookmarkRepository } from '../bookmark/bookmark.repository';
+import { ElasticsearchModule } from '@nestjs/elasticsearch';
 
 @Module({
   controllers: [PostController],
@@ -33,7 +34,20 @@ import { BookmarkRepository } from '../bookmark/bookmark.repository';
     SearchHistoryMongoRepository,
     PostSubscriber,
   ],
-  imports: [HttpModule, JwtModule.register({})], // TODO App으로 올릴지 이야기하기
-  exports: [PostService, PostRepository],
+  imports: [
+    HttpModule,
+    JwtModule.register({}),
+    ElasticsearchModule.registerAsync({
+      useFactory: () => ({
+        // TODO env로 이동
+        node: 'http://localhost:9200',
+        maxRetries: 10,
+        requestTimeout: 60000,
+        pingTimeout: 60000,
+        sniffOnStart: true,
+      }),
+    }),
+  ], // TODO App으로 올릴지 이야기하기
+  exports: [PostService, PostRepository, ElasticsearchModule],
 })
 export class PostModule {}

--- a/server/src/domain/post/post.module.ts
+++ b/server/src/domain/post/post.module.ts
@@ -16,6 +16,7 @@ import { SearchHistoryMongoRepository } from '../search/search-history.mongo.rep
 import { BookmarkService } from '../bookmark/bookmark.service';
 import { BookmarkRepository } from '../bookmark/bookmark.repository';
 import { ElasticsearchModule } from '@nestjs/elasticsearch';
+import { PostSearchService } from './post-search.service';
 
 @Module({
   controllers: [PostController],
@@ -25,6 +26,7 @@ import { ElasticsearchModule } from '@nestjs/elasticsearch';
     AuthService,
     UserService,
     BookmarkService,
+    PostSearchService,
     PostRepository,
     TagRepository,
     PostToTagRepository,

--- a/server/src/domain/post/post.module.ts
+++ b/server/src/domain/post/post.module.ts
@@ -17,6 +17,7 @@ import { BookmarkService } from '../bookmark/bookmark.service';
 import { BookmarkRepository } from '../bookmark/bookmark.repository';
 import { ElasticsearchModule } from '@nestjs/elasticsearch';
 import { PostSearchService } from './post-search.service';
+import { ImageRepository } from '../image/image.repository';
 
 @Module({
   controllers: [PostController],
@@ -35,6 +36,7 @@ import { PostSearchService } from './post-search.service';
     LikesRepository,
     SearchHistoryMongoRepository,
     PostSubscriber,
+    ImageRepository,
   ],
   imports: [
     HttpModule,

--- a/server/src/domain/post/post.module.ts
+++ b/server/src/domain/post/post.module.ts
@@ -18,6 +18,7 @@ import { BookmarkRepository } from '../bookmark/bookmark.repository';
 import { ElasticsearchModule } from '@nestjs/elasticsearch';
 import { PostSearchService } from './post-search.service';
 import { ImageRepository } from '../image/image.repository';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 
 @Module({
   controllers: [PostController],
@@ -41,17 +42,24 @@ import { ImageRepository } from '../image/image.repository';
   imports: [
     HttpModule,
     JwtModule.register({}),
+    ConfigModule,
     ElasticsearchModule.registerAsync({
-      useFactory: () => ({
+      imports: [ConfigModule],
+      useFactory: async (configService: ConfigService) => ({
         // TODO env로 이동
-        node: 'http://localhost:9200',
-        maxRetries: 10,
-        requestTimeout: 60000,
-        pingTimeout: 60000,
-        sniffOnStart: true,
+        node: configService.get('ELASTICSEARCH_URL'),
+        auth: {
+          username: configService.get('ELASTICSEARCH_USERNAME'), //TODO username, password 넣기
+          password: configService.get('ELASTICSEARCH_PASSWORD'),
+        },
+        maxRetries: configService.get('ELASTICSEARCH_MAX_RETRIES'),
+        requestTimeout: configService.get('ELASTICSEARCH_REQUEST_TIMEOUT'),
+        pingTimeout: configService.get('ELASTICSEARCH_PING_TIMEOUT'),
+        sniffOnStart: configService.get('ELASTICSEARCH_SNIFF_ON_START'),
       }),
+      inject: [ConfigService],
     }),
-  ], // TODO App으로 올릴지 이야기하기
+  ],
   exports: [PostService, PostRepository, ElasticsearchModule],
 })
 export class PostModule {}

--- a/server/src/domain/post/post.repository.ts
+++ b/server/src/domain/post/post.repository.ts
@@ -119,4 +119,31 @@ export class PostRepository extends Repository<Post> {
       .where('post.id = :postId', { postId: postId })
       .getOne();
   }
+
+  increaseLikeCount(post: Post) {
+    this.createQueryBuilder()
+      .update(Post)
+      .set({ likeCount: () => 'likeCount + 1' })
+      .where('id=:id', { id: post.id })
+      .execute();
+  }
+
+  decreaseLikeCount(post: Post) {
+    if (post.likeCount <= 0) {
+      return;
+    }
+    this.createQueryBuilder()
+      .update(Post)
+      .set({ likeCount: () => 'likeCount - 1' })
+      .where('id=:id', { id: post.id })
+      .execute();
+  }
+
+  increaseReviewCount(post: Post) {
+    this.createQueryBuilder()
+      .update(Post)
+      .set({ reviewCount: () => 'reviewCount + 1' })
+      .where('id=:id', { id: post.id })
+      .execute();
+  }
 }

--- a/server/src/domain/post/post.service.spec.ts
+++ b/server/src/domain/post/post.service.spec.ts
@@ -36,7 +36,22 @@ describe('PostService', () => {
         UserRepository,
         TagRepository,
         ImageRepository,
-        PostSearchService,
+        {
+          provide: PostSearchService,
+          useValue: {
+            indexPost: () => jest.fn(),
+            search: () =>
+              jest.fn().mockResolvedValue({
+                hits: {
+                  hits: [
+                    { _source: { id: 1 } },
+                    { _source: { id: 2 } },
+                    { _source: { id: 3 } },
+                  ],
+                },
+              }),
+          },
+        },
         {
           provide: DataSource,
           useValue: {
@@ -72,6 +87,7 @@ describe('PostService', () => {
     expect(service).toBeDefined();
   });
 
+  // TODO PostService에서 글 작성시, 중복된 태그 입력하면 예외 처리하기
   describe('글 작성', () => {
     const writeDto: WriteDto = {
       title: '제목',
@@ -98,6 +114,9 @@ describe('PostService', () => {
       tagRepository.findOneBy = jest.fn(
         () => new Promise((resolve) => resolve(new Tag())),
       );
+      const post = new Post();
+      post.id = 1;
+      postRepository.save = jest.fn().mockResolvedValue(post);
       await service.write(1, writeDto);
 
       expect(postRepository.save).toBeCalledTimes(1);

--- a/server/src/domain/post/post.service.ts
+++ b/server/src/domain/post/post.service.ts
@@ -62,7 +62,7 @@ export class PostService {
     postEntity.userNickname = userEntity.nickname;
 
     postEntity = await this.postRepository.save(postEntity);
-    this.postSearchService.indexPost(postEntity, tags); // TODO 데이터 더미로 넣을때 주석처리. 배치로 넣는게 더 빠름
+    this.postSearchService.indexPost(postEntity, tags);
 
     return postEntity.id;
   }

--- a/server/src/domain/post/post.service.ts
+++ b/server/src/domain/post/post.service.ts
@@ -122,7 +122,6 @@ export class PostService {
   ): Promise<SearchResponseDto> {
     let isLast = true;
     const results = await this.postSearchService.search(loadPostListRequestDto);
-    results.reverse();
     if (this.canGetNextPost(results.length)) {
       results.pop();
       isLast = false;
@@ -139,7 +138,7 @@ export class PostService {
       );
       images.push(
         this.imageRepository.findBy({
-          postId: Number(result._id),
+          postId: Number(result._source['id']),
         }),
       );
     }

--- a/server/src/domain/post/post.service.ts
+++ b/server/src/domain/post/post.service.ts
@@ -32,6 +32,7 @@ export class PostService {
     userId: number,
     { title, content, code, language, lineCount, images, tags },
   ) {
+    // TODO 입력값 검증
     tags.sort();
 
     const userEntity = await this.userRepository.findOneBy({

--- a/server/src/domain/post/post.service.ts
+++ b/server/src/domain/post/post.service.ts
@@ -123,6 +123,9 @@ export class PostService {
   ): Promise<SearchResponseDto> {
     let isLast = true;
     const results = await this.postSearchService.search(loadPostListRequestDto);
+    if (results.length > SEND_POST_CNT + 1) {
+      throw new Error('너무 많은 검색 결과가 반환되었습니다');
+    }
     if (this.canGetNextPost(results.length)) {
       results.pop();
       isLast = false;

--- a/server/src/domain/post/types/post-search-body.interface.ts
+++ b/server/src/domain/post/types/post-search-body.interface.ts
@@ -11,6 +11,7 @@ interface PostSearchBody {
   authorNickname: string;
   tags: string;
   likeCount: number;
+  reviewCount: number;
   lineCount: number;
 }
 

--- a/server/src/domain/post/types/post-search-body.interface.ts
+++ b/server/src/domain/post/types/post-search-body.interface.ts
@@ -4,10 +4,9 @@ interface PostSearchBody {
   content: string;
   code: string;
   language: string;
-  // TODO 이미지 url은 필요없음. 가져올거임
   createdAt: Date;
   updatedAt: Date;
-  authorId: number; // TODO Author 관해서도 가져올거임
+  authorId: number;
   authorNickname: string;
   tags: string;
   likeCount: number;

--- a/server/src/domain/post/types/post-search-body.interface.ts
+++ b/server/src/domain/post/types/post-search-body.interface.ts
@@ -10,7 +10,7 @@ interface PostSearchBody {
   authorId: number; // TODO Author 관해서도 가져올거임
   authorNickname: string;
   tags: string;
-  // likesCount: number;
+  likeCount: number;
   lineCount: number;
 }
 

--- a/server/src/domain/post/types/post-search-body.interface.ts
+++ b/server/src/domain/post/types/post-search-body.interface.ts
@@ -2,10 +2,16 @@ interface PostSearchBody {
   id: number;
   title: string;
   content: string;
+  code: string;
   language: string;
-  authorId: number;
+  // TODO 이미지 url은 필요없음. 가져올거임
+  createdAt: Date;
+  updatedAt: Date;
+  authorId: number; // TODO Author 관해서도 가져올거임
   authorNickname: string;
   tags: string;
+  // likesCount: number;
+  lineCount: number;
 }
 
 interface PostSearchResult {

--- a/server/src/domain/post/types/post-search-body.interface.ts
+++ b/server/src/domain/post/types/post-search-body.interface.ts
@@ -1,0 +1,18 @@
+interface PostSearchBody {
+  id: number;
+  title: string;
+  content: string;
+  language: string;
+  authorId: number;
+  authorNickname: string;
+  tags: string;
+}
+
+interface PostSearchResult {
+  hits: {
+    total: number;
+    hits: Array<{
+      _source: PostSearchBody;
+    }>;
+  };
+}

--- a/server/src/domain/review/review.service.ts
+++ b/server/src/domain/review/review.service.ts
@@ -50,6 +50,7 @@ export class ReviewService {
     reviewEntity.content = content;
 
     await this.reviewRepository.insert(reviewEntity);
+    this.postRepository.increaseReviewCount(postEntity);
   }
 
   async getReviewsOfPost(postId: number, { lastId }: ReviewGetAllRequestDto) {

--- a/server/src/exception/post-input-invalid.exception.ts
+++ b/server/src/exception/post-input-invalid.exception.ts
@@ -1,0 +1,5 @@
+export class PostInputInvalidException extends Error {
+  constructor(msg: string) {
+    super(msg);
+  }
+}

--- a/server/src/exception/search-param-invalid.exception.ts
+++ b/server/src/exception/search-param-invalid.exception.ts
@@ -1,0 +1,5 @@
+export class SearchParamInvalidException extends Error {
+  constructor(msg: string) {
+    super(msg);
+  }
+}

--- a/server/src/exception/search-response-invalid.exception.ts
+++ b/server/src/exception/search-response-invalid.exception.ts
@@ -1,0 +1,5 @@
+export class SearchResponseInvalidException extends Error {
+  constructor(msg) {
+    super(msg);
+  }
+}

--- a/server/src/exception/tag-invalid.exception.ts
+++ b/server/src/exception/tag-invalid.exception.ts
@@ -1,0 +1,5 @@
+export class TagInvalidException extends Error {
+  constructor(msg) {
+    super(msg);
+  }
+}


### PR DESCRIPTION
# 요약
검색의 효율성을 높여주는 Elastic Search를 적용하였습니다.
엘라스틱 서치의 효율을 높이기 위해 Post 엔티티에 역정규화를 진행하였습니다.

- 변경 전
<img width="407" alt="스크린샷 2022-12-12 오후 5 53 50" src="https://user-images.githubusercontent.com/67636607/207002483-3f11ee18-66b2-4447-9a7b-f1817c29a2f5.png">

- 변경 후
<img width="407" alt="스크린샷 2022-12-12 오후 5 53 28" src="https://user-images.githubusercontent.com/67636607/207002404-1c87b4a9-7858-4946-a265-0342c9ef7950.png">

- 성능 변화 (데이터 50만개 기준)
  - 조건 없이 최근 데이터만 가져올 때 (큰 차이 없음. 평균치 비슷하게 나옴)
    <img width="357" alt="스크린샷 2022-12-12 오후 6 00 59" src="https://user-images.githubusercontent.com/67636607/207005214-011b7390-2f7f-42d9-98f1-54511978644a.png">
    <img width="346" alt="스크린샷 2022-12-12 오후 6 10 02" src="https://user-images.githubusercontent.com/67636607/207006046-13a15b51-3f52-48ec-a6aa-3c1597013691.png">



  - 조건을 사용 후, 검색 결과가 있을 때
    <img width="368" alt="스크린샷 2022-12-12 오후 6 00 50" src="https://user-images.githubusercontent.com/67636607/207005292-11ff645a-75a2-4037-a69b-817b03e9e556.png">
    <img width="360" alt="스크린샷 2022-12-12 오후 5 57 42" src="https://user-images.githubusercontent.com/67636607/207003379-13d0d70f-bedf-4b12-9a66-ebe503b33808.png">



  - 조건을 사용 후, 검색 결과가 없을 때
    <img width="386" alt="스크린샷 2022-12-12 오후 6 01 23" src="https://user-images.githubusercontent.com/67636607/207005104-91eea8d5-e86e-4342-ab6a-ef84a2e77de0.png">
    <img width="363" alt="스크린샷 2022-12-12 오후 5 58 16" src="https://user-images.githubusercontent.com/67636607/207005148-fe3cb0c8-313d-4dae-87ed-910a52321639.png">

- 고려해야 할 점
  - DB가 분리되어 데이터 정합성이 깨질 수 있습니다. 따라서 Logstash를 사용해 배치 작업을 걸 계획입니다.
  - 역정규화가 일어나 데이터 정합성이 깨질 수 있습니다. 스케쥴러를 통해 주기적으로 데이터 정합성을 맞출 계획입니다.

# 연관 이슈
- related #377 

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
    - 좋은 예시) feat [FE] : 깃허브 로그인 버튼 컴포넌트 구현 (#13)
    - 나쁜 예시) feat: 로그인 구현