### PR TITLE
인기 태그를 24시간동안 유지하도록 변경했습니다.

### DIFF
--- a/scheduler-server/src/ranking/ranking.service.ts
+++ b/scheduler-server/src/ranking/ranking.service.ts
@@ -15,7 +15,7 @@ export class RankingService {
 
   constructor() {
     this.tagsCountsCircularQueue = new Array(
-      (MINUTES_PER_HOUR / QUEUE_CYCLE_EXPRESSED_SECOND) * MINUTES_PER_HOUR,
+      (MINUTES_PER_HOUR / QUEUE_CYCLE_EXPRESSED_SECOND) * MINUTES_PER_HOUR * 24,
     );
     this.tagCountBuffer = {};
     this.ranking = [];


### PR DESCRIPTION
# 요약
- 기존 1시간동안 유지했던 인기 태그를 24시간동안 유지하도록 변경했습니다.

# 연관 이슈
- related #392 

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
    - 좋은 예시) feat [FE] : 깃허브 로그인 버튼 컴포넌트 구현 (#13)
    - 나쁜 예시) feat: 로그인 구현