### PR TITLE
fix(FE): URL에 해시태그가 있을 경우 주석처리되는 오류 해결 및 Mock 테스트 추가 (#410)

### DIFF
--- a/client/src/hooks/useLabel.ts
+++ b/client/src/hooks/useLabel.ts
@@ -75,7 +75,7 @@ const useLabel = (): UseLabelResult => {
   );
 
   // PostScroll 에 현재 검색 필터를 적용
-  const handleSubmit = (searchLabels: Label[] = labels): void => {
+  const handleSubmit = (searchLabels: Label[] | undefined = labels): void => {
     navigate("/");
     searchDefaultFilter(createSearchFilter(searchLabels));
   };

--- a/client/src/mocks/datasource/mockDataSource.ts
+++ b/client/src/mocks/datasource/mockDataSource.ts
@@ -35,8 +35,8 @@ posts = Array.from(Array(1024).keys()).map((id) => ({
     email: `name_${id + 10000}@gmail.com`,
   },
   tags: [
-    "javascript",
-    "js",
+    "#javascript",
+    "#js",
     "es6",
     "typescript",
     "python",

--- a/client/src/utils/queryString.ts
+++ b/client/src/utils/queryString.ts
@@ -6,7 +6,9 @@ export const setQueryString = (searchingObj: SearchFilter): string =>
     .filter(([key, value]) => key === "lastId" || isQueryTypeFine(value))
     .map(([key, value]) => {
       if (Array.isArray(value)) {
-        return `${value.map((v) => `${key}[]=${encodeURI(v)}`).join("&")}`;
+        return `${value
+          .map((v) => `${key}[]=${encodeURIComponent(v)}`)
+          .join("&")}`;
       }
       return `${key}=${String(encodeURI(value))}`;
     })


### PR DESCRIPTION
# 요약
![image](https://user-images.githubusercontent.com/63703962/207060214-9e13cbe9-5cbd-4d02-8519-b27b70f7cc3f.png)

- encodeURI -> encodeURIComponent 사용하도록 변경
- 해시태그(#)는 그 뒤의 정보가 서버로 전송되지 않음

# 연관 이슈

- fix #410 
<!--이슈 번호를 적어주세요(예시: fix #123). -->

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
    - 좋은 예시) feat [FE] : 깃허브 로그인 버튼 컴포넌트 구현 (#13)
    - 나쁜 예시) feat: 로그인 구현