### PR TITLE
검색이 이상하게 되는 경우들을 수정하였습니다.

### DIFF
--- a/server/src/domain/post/post-search.service.spec.ts
+++ b/server/src/domain/post/post-search.service.spec.ts
@@ -235,10 +235,7 @@ describe('PostSearchService', () => {
         searchCondition.tags = ['one'];
         searchConditionUsingES.body.query.bool.filter.bool.must.push({
           match: {
-            tags: {
-              query: 'one',
-              operator: 'AND',
-            },
+            tags: 'one',
           },
         });
 
@@ -252,14 +249,13 @@ describe('PostSearchService', () => {
       it('tags가 다섯 개 들어왔을 때, 정상 출력한다', async () => {
         //given
         searchCondition.tags = ['one', 'two', 'three', 'four', 'five'];
-        searchConditionUsingES.body.query.bool.filter.bool.must.push({
-          match: {
-            tags: {
-              query: ['one', 'two', 'three', 'four', 'five'].join(' '),
-              operator: 'AND',
+        for (const tag of searchCondition.tags) {
+          searchConditionUsingES.body.query.bool.filter.bool.must.push({
+            match: {
+              tags: tag,
             },
-          },
-        });
+          });
+        }
 
         //when
         await service.search(searchCondition);

--- a/server/src/domain/post/post.entity.ts
+++ b/server/src/domain/post/post.entity.ts
@@ -52,4 +52,7 @@ export class Post extends BaseTimeEntity {
 
   @Column({ length: 24, default: '' })
   userNickname: string;
+
+  @Column()
+  userId!: number;
 }

--- a/server/src/domain/post/post.service.ts
+++ b/server/src/domain/post/post.service.ts
@@ -133,7 +133,6 @@ export class PostService {
 
     const authors = [];
     const images = [];
-
     for (const result of results) {
       authors.push(
         this.userRepository.findOneBy({

--- a/server/src/domain/post/post.service.ts
+++ b/server/src/domain/post/post.service.ts
@@ -137,7 +137,7 @@ export class PostService {
     for (const result of results) {
       authors.push(
         this.userRepository.findOneBy({
-          id: result._source['authorId'],
+          id: result._source['authorid'],
         }),
       );
       images.push(


### PR DESCRIPTION
# 요약
- 사용자 아이디가 이상하게 나온 이유는 검색결과를 가져오는 elasticsearch에서 userid 컬럼이 존재하지 않았습니다.

사용자 닉네임은 중복이 가능한 관계로 userId 컬럼을 post에 역정규화 하였습니다.

- 태그 검색이 제대로 되지 않는 이슈를 수정하였습니다. mapping 타입이 text가 아닌 keyword로 설정되어 있었습니다.
이전에 Nested로 태그를 저장할지, 문자열 그대로 저장할 지 고민하던 과정에서, 지우지 못하고 설정에 그대로 남아있던 코드입니다.
index를 지우고 다시 mapping을 진행해 해결하였습니다.

# 연관 이슈
- related #432 
# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
    - 좋은 예시) feat [FE] : 깃허브 로그인 버튼 컴포넌트 구현 (#13)
    - 나쁜 예시) feat: 로그인 구현