### PR TITLE
엘라스틱서치 변경 후 Post가 삭제되지 않는 이슈를 해결하였습니다.

### DIFF
--- a/server/src/domain/post/post-search.service.ts
+++ b/server/src/domain/post/post-search.service.ts
@@ -202,4 +202,15 @@ export class PostSearchService {
       throw new TagInvalidException('태그의 길이가 너무 깁니다');
     }
   }
+
+  async delete(id: number) {
+    await this.esService.deleteByQuery({
+      index: this.configService.get<string>('ELASTICSEARCH_INDEX'),
+      body: {
+        query: {
+          match: { id: id },
+        },
+      },
+    });
+  }
 }

--- a/server/src/domain/post/post.service.spec.ts
+++ b/server/src/domain/post/post.service.spec.ts
@@ -50,6 +50,7 @@ describe('PostService', () => {
                   ],
                 },
               }),
+            delete: () => jest.fn(),
           },
         },
         {

--- a/server/src/domain/post/post.service.ts
+++ b/server/src/domain/post/post.service.ts
@@ -107,6 +107,7 @@ export class PostService {
     }
     post.isDeleted = true;
     await this.postRepository.deleteUsingPost(post);
+    await this.postSearchService.delete(post.id);
   }
 
   async inquiryPost(postId: number) {


### PR DESCRIPTION
# 요약
MySQL에서만 Post를 지우고, 엘라스틱서치에서는 적용하지 않아 발생한 이슈였습니다.
엘라스틱서치에서도 데이터를 지워 정합성을 맞춰줍니다.

삭제 이벤트가 발생하면 딜레이 없이 바로 삭제할 필요가 있다 생각해, 배치 작업을 걸지 않고 바로 삭제 이벤트를 적용시켜주었습니다.

# 연관 이슈
- related #441 
# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
    - 좋은 예시) feat [FE] : 깃허브 로그인 버튼 컴포넌트 구현 (#13)
    - 나쁜 예시) feat: 로그인 구현