### PR TITLE
fix(FE): 메뉴 버튼 클릭 시 / 로 네비게이션 되도록 오류 수정 (#420)

### DIFF
--- a/client/src/hooks/useNav.ts
+++ b/client/src/hooks/useNav.ts
@@ -1,3 +1,5 @@
+import { useNavigate } from "react-router-dom";
+
 import useNavStore, { NAV_STATE, NAV_STATE_TYPE } from "@/store/useNavStore";
 
 type NavClickHandler = (fn?: Function) => void;
@@ -19,6 +21,7 @@ interface UseNavResult {
 }
 
 const useNav = (): UseNavResult => {
+  const navigate = useNavigate();
   const [navState, setNavState] = useNavStore((state) => [
     state.navState,
     state.setNavState,
@@ -26,6 +29,7 @@ const useNav = (): UseNavResult => {
 
   const handleNav =
     (newNavState: NAV_STATE_TYPE) => (fn: Function | undefined) => {
+      navigate("/");
       const state = navState === newNavState ? NAV_STATE.DEFAULT : newNavState;
       setNavState(state);
       if (fn !== undefined) {


### PR DESCRIPTION
# 요약

URL이 이미 post/postId인 상태에서 다시 navigate 하는 동작이 일어나지 않는 것 같아서 메뉴를 눌러서 넘어갈 경우 URL을 /로 다시 돌려주는 기능 추가

# 연관 이슈

- fix #420
<!--이슈 번호를 적어주세요(예시: fix #123). -->

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
    - 좋은 예시) feat [FE] : 깃허브 로그인 버튼 컴포넌트 구현 (#13)
    - 나쁜 예시) feat: 로그인 구현