### PR TITLE
fix(FE): 미인증 상태에서 로그인 클릭 시 401 응답으로 출력하는 오류 수정 (#420)

### DIFF
--- a/client/src/components/main/MainNav/NavMenus/BookmarkMenu/BookmarkMenu.tsx
+++ b/client/src/components/main/MainNav/NavMenus/BookmarkMenu/BookmarkMenu.tsx
@@ -4,15 +4,20 @@ import BookmarksOutlinedIcon from "@mui/icons-material/BookmarksOutlined";
 import NavMenu from "@/components/main/MainNav/NavMenus/NavMenu/NavMenu";
 import useNav from "@/hooks/useNav";
 import useSearchStore from "@/store/useSearchStore";
+import useAuth from "@/hooks/useAuth";
 
 const BookmarkMenu = (): JSX.Element => {
   const { handleBookmark } = useNav();
+  const { checkLogin } = useAuth();
   const searchBookmarkFilter = useSearchStore(
     (state) => state.searchBookmarkFilter
   );
 
   const handleMenuClick: MouseEventHandler = () => {
-    handleBookmark(searchBookmarkFilter);
+    if (checkLogin()) {
+      console.log("hello");
+      handleBookmark(searchBookmarkFilter);
+    }
   };
 
   return (

--- a/client/src/hooks/useAuth.ts
+++ b/client/src/hooks/useAuth.ts
@@ -10,6 +10,7 @@ interface UseAuthResult {
   myInfo: MyInfo | null;
   handleLogin: () => void;
   handleLogout: () => void;
+  checkLogin: () => boolean;
 }
 
 const useAuth = (): UseAuthResult => {
@@ -38,7 +39,16 @@ const useAuth = (): UseAuthResult => {
       });
   };
 
-  return { isLoggedIn, myInfo, handleLogin, handleLogout };
+  const checkLogin = (): boolean => {
+    if (isLoggedIn) {
+      return true;
+    }
+    alert("로그인이 필요합니다.");
+    handleLogin();
+    return false;
+  };
+
+  return { isLoggedIn, myInfo, handleLogin, handleLogout, checkLogin };
 };
 
 export default useAuth;


### PR DESCRIPTION
# 요약

- 기존 로직 : 미인증 상태에서 먼저 서버에 요청 -> 401응답과 함께 undeined 데이터 수신 -> 로그인 팝업-로그인 -> undefined 데이터로 포스트 정보 표시(오류)
- 수정 로직 : 미인증 상태에서는 로그인 요청-로그인 까지만 진행되고 실제 api호출이 가지 않도록 수정

# 연관 이슈

- fix #420 
<!--이슈 번호를 적어주세요(예시: fix #123). -->

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
    - 좋은 예시) feat [FE] : 깃허브 로그인 버튼 컴포넌트 구현 (#13)
    - 나쁜 예시) feat: 로그인 구현