### PR TITLE
fix(BE): 태그들을 각 배열의 원소로 분리 (#450)

### DIFF
--- a/server/src/domain/post/dto/controller-response.dto.ts
+++ b/server/src/domain/post/dto/controller-response.dto.ts
@@ -51,23 +51,14 @@ class EachSearchResponseDto {
   lineCount: number;
 
   constructor(post: any, author, images) {
-    let tags;
-    try {
-      tags = JSON.parse(post._source.tags);
-    } catch (e) {
-      if (post._source.tags.length > 0) {
-        tags = [post._source.tags];
-      } else {
-        tags = [];
-      }
-    }
     this.id = post._source.id;
     this.title = post._source.title;
     this.content = post._source.content;
     this.code = post._source.code;
     this.language = post._source.language;
     this.updatedAt = post._source.updatedat;
-    this.tags = tags;
+    this.tags =
+      post._source.tags.length === 0 ? [] : post._source.tags.split(' ');
     this.isLiked = false;
     this.isBookmarked = false;
     this.likesCount = post._source.likecount;


### PR DESCRIPTION
# 요약
<img width="349" alt="스크린샷 2022-12-15 오후 9 49 15" src="https://user-images.githubusercontent.com/67636607/207864519-e1f4ec31-eaf4-41d6-a174-f0025a2a9bec.png">

태그가 배열 안에 제대로 분리되지 않는 이슈를 해결하였습니다.
기존에 `["tag1","tag2"]`와 같이 반환되던 태그를 엘라스틱 서치 내부에서 `tag1 tag2` 방식으로 저장하도록 변경했고,
서버에서 제대로 파싱을 처리해주지 않아 다음과 같은 오류가 발생했습니다.

# 연관 이슈
- related # 450

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
    - 좋은 예시) feat [FE] : 깃허브 로그인 버튼 컴포넌트 구현 (#13)
    - 나쁜 예시) feat: 로그인 구현