### PR TITLE
v1.0.2 마이너 패치 - README.md 공백 작성, 검색 조건 태그 개수제한 적용 (#456)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,14 @@
 
 <div align="center">
 
-<img width="100%" alt="섬네일" src="https://user-images.githubusercontent.com/63703962/207874401-2a180dd8-e16e-469d-ba47-9979b7b2034e.png">
+<img width="100%" alt="섬네일" src="https://user-images.githubusercontent.com/63703962/207881675-2f68dbd5-9b13-4812-b183-0fe058f9eb74.svg">
 
-[💻 WeView](https://weview.club) | [📽 발표 영상](https://www.youtube.com/watch?v=-cujznqSkC4) | [📷 데모 영상](https://youtu.be/bK0whd-zuck) | [📝 팀 위키](https://github.com/boostcampwm-2022/web06-weview/wiki)
+</br>
+</br>
+
+### [💻 WeView](https://weview.club) | [📽 발표 영상](https://www.youtube.com/watch?v=-cujznqSkC4) | [📷 데모 영상](https://youtu.be/bK0whd-zuck) | [📝 팀 위키](https://github.com/boostcampwm-2022/web06-weview/wiki)
+
+</br>
 
 </div>
 
@@ -17,9 +22,9 @@
 **💡 WeView 팀은 사용자가 즐길 수 있는 가치를 전달하는 방법으로 3가지를 생각했어요.**
 
 > 1. 간단하게 코드를 확인하고 리뷰 할 수 있어요.
-> 
+>
 > 2. 보고 싶은 코드를 쉽게 찾을 수 있어요.
-> 
+>
 > 3. 한눈에 코드들이 들어오는 디자인을 생각했어요.
 
 ## 저희 ‍김가네 식구들을 소개할게요.
@@ -48,11 +53,10 @@
 
 더 궁금하시다면 아래를 참고해주세요.
 
-- 주요 기능이 궁금해요. 👉 [WeView 사용 설명서 바로가기]()
-- 프로젝트를 직접 설치하고 싶어요. 👉 [설치 가이드 바로가기]()
-- 협업 방식을 알아보고 싶어요. 👉 [협업 가이드 바로가기]()
-- 사용한 기술이 궁금해요. 👉 [기술 스펙 바로가기]()
-- 기술을 선정한 이유가 궁금해요. 👉 [기술 선정 이유 바로가기]()
-- 프로젝트를 하면서 겪은 이야기가 궁금해요. 👉 [기술 블로그 바로가기]()
+- 주요 기능이 궁금해요. 👉 [WeView 사용 설명서 바로가기](https://github.com/boostcampwm-2022/web06-weview/wiki/%EC%82%AC%EC%9A%A9-%EC%84%A4%EB%AA%85%EC%84%9C)
+- 프로젝트를 직접 설치하고 싶어요. 👉 [설치 가이드 바로가기](https://github.com/boostcampwm-2022/web06-weview/wiki/%EC%84%A4%EC%B9%98-%EA%B0%80%EC%9D%B4%EB%93%9C)
+- 협업 방식을 알아보고 싶어요. 👉 [협업 가이드 바로가기](https://github.com/boostcampwm-2022/web06-weview/wiki/%F0%9F%93%9C-%ED%98%91%EC%97%85-%EA%B0%80%EC%9D%B4%EB%93%9C)
+- 사용한 기술이 궁금해요. 👉 [기술 스펙 바로가기](https://github.com/boostcampwm-2022/web06-weview/wiki/%F0%9F%97%82-%EA%B8%B0%EC%88%A0-%EC%8A%A4%ED%8E%99)
+- 프로젝트를 하면서 겪은 이야기가 궁금해요. 👉 [기술 블로그 바로가기](https://github.com/boostcampwm-2022/web06-weview/wiki/%F0%9F%92%BB-%EA%B0%9C%EB%B0%9C-%EB%B8%94%EB%A1%9C%EA%B7%B8)
 
 다른 이야기들은 [📝 팀 위키](https://github.com/boostcampwm-2022/web06-weview/wiki)에서 확인해 보실 수 있어요.

--- a/client/src/constants/search.ts
+++ b/client/src/constants/search.ts
@@ -15,3 +15,4 @@ export const REVIEW_COUNT_ITEMS = [
 ];
 
 export const MAX_SEARCH_HISTORY = 5;
+export const MAX_SEARCH_TAGS_COUNT = 5;

--- a/client/src/hooks/useSearch.ts
+++ b/client/src/hooks/useSearch.ts
@@ -14,6 +14,7 @@ import {
 } from "@/utils/label";
 import { LABEL_NAME } from "@/constants/label";
 import { formatTag } from "@/utils/regExpression";
+import { MAX_SEARCH_TAGS_COUNT } from "@/constants/search";
 
 interface UseLabelResult {
   word: string;
@@ -127,7 +128,11 @@ const useSearch = (
   };
 
   const handleInsertTag = (e: KeyboardEvent<HTMLInputElement>): void => {
-    if (word.length === 0 || !isEnterKey(e.key)) {
+    if (
+      word.length === 0 ||
+      !isEnterKey(e.key) ||
+      MAX_SEARCH_TAGS_COUNT <= labels.length
+    ) {
       return;
     }
     const newLabel = createLabel(formatTag(word.trim()), LABEL_NAME.TAGS);


### PR DESCRIPTION
# 요약

- README.md 사이에 공백을 누락한 오류를 해결했습니다.
- 태그 검색 시 5개까지 검색이 되는 조건을 추가했습니다.

# 연관 이슈

- related #456 
<!--이슈 번호를 적어주세요(예시: fix #123). -->

# Pull Request 체크리스트

## TODO

- [x] 최종 결과물을 확인했는가?
- [x] 의미 있는 커밋 메시지를 작성했는가?
    - 좋은 예시) feat [FE] : 깃허브 로그인 버튼 컴포넌트 구현 (#13)
    - 나쁜 예시) feat: 로그인 구현